### PR TITLE
Make integration tests dependent on unit/linting

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -3,8 +3,8 @@ name: Pull Request
 on:
   workflow_call:
     secrets:
-       CHARMHUB_TOKEN:
-         required: true
+      CHARMHUB_TOKEN:
+        required: true
 jobs:
   lib-check:
     name: Check libraries
@@ -30,4 +30,9 @@ jobs:
     uses: canonical/observability/.github/workflows/_unit-tests.yaml@main
   integration-test:
     name: Integration Tests
+    needs:
+      - lib-check
+      - static-analysis
+      - linting
+      - unit-test
     uses: canonical/observability/.github/workflows/_integration-tests.yaml@main


### PR DESCRIPTION
I think this might be a sensible change to avoid wasting lots of cycles on integration tests in cases where the basics (unit/lint/static) fail?

This way we'll only run the integration tests when the PR is fit to be integration tested.