### PR TITLE
Bump charming-actions to 2.1.0

### DIFF
--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -16,10 +16,10 @@ jobs:
         with:
           fetch-depth: 1
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.0.0
+        uses: canonical/charming-actions/channel@2.1.0
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.0.0
+        uses: canonical/charming-actions/upload-charm@2.1.0
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
"Release to Charmhub" action [fails now](https://github.com/canonical/prometheus-k8s-operator/actions/runs/3245651436/jobs/5324554105) because:

> charmcraft 2.1.0 breaks the upload-action: when passing an --image to charmcraft for uploading, it has to be a digest and not just a tagged image name
>
> -- @ca-scribner 

[charming-actions 2.1.0](https://github.com/canonical/charming-actions/releases/tag/2.1.0) fixes this.