### PR TITLE
Revert agent version to 2.9.34

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           juju-channel: 2.9/stable
           provider: microk8s
-          bootstrap-options: "--agent-version 2.9.37"
+          bootstrap-options: "--agent-version 2.9.34"
       - name: Patch hostpath-provisioner
         run: >
           sg microk8s -c "kubectl patch deployment hostpath-provisioner -n kube-system -p '{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\":\"hostpath-provisioner\", \"image\": \"cdkbot/hostpath-provisioner:1.3.0\" }] }}}}'"


### PR DESCRIPTION
Version 2.9.37 [fails CI](https://github.com/canonical/cos-configuration-k8s-operator/actions/runs/3489415420/jobs/5839513802). Reverting to v34.