### PR TITLE
Use full version number for python 3.5

### DIFF
--- a/.github/workflows/_static-analysis.yaml
+++ b/.github/workflows/_static-analysis.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python 3.5
         uses: actions/setup-python@v4
         with:
-          python-version: 3.5
+          python-version: 3.5.10
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run static analysis for /lib for 3.5


### PR DESCRIPTION
CI [errors out](https://github.com/canonical/traefik-k8s-operator/actions/runs/3621986696/jobs/6106127850) with:
```
Run actions/setup-python@v4
  with:
    python-version: 3.5
    check-latest: false
    token: ***
    update-environment: true
Version 3.5 was not found in the local cache
Error: Version 3.5 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```
And indeed, [versions-manifest.json](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json) does not explicitly list "3.5".