### PR TITLE
Run static lib on 20.04

### DIFF
--- a/.github/workflows/_static-analysis.yaml
+++ b/.github/workflows/_static-analysis.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   static-lib:
     name: Static Analysis of Libs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
No python 3.5 on 22.04, which is now wat comes for ubuntu-latest