### PR TITLE
feature(ci): validate alert rules

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -43,6 +43,9 @@ jobs:
   linting:
     name: Linting
     uses: canonical/observability/.github/workflows/_linting.yaml@main
+  validate-rules:
+    name: Validate rules
+    uses: canonical/observability/.github/workflows/_validate_rules.yaml@main
   unit-test:
     name: Unit Tests
     uses: canonical/observability/.github/workflows/_unit-tests.yaml@main

--- a/.github/workflows/_validate_rules.yaml
+++ b/.github/workflows/_validate_rules.yaml
@@ -17,6 +17,6 @@ jobs:
           wget https://github.com/canonical/cos-tool/releases/download/rel-20220621/cos-tool-amd64
           chmod +x ./cos-tool-amd64
       - name: Validate prometheus alert rules
-        run: find . -path '*/prometheus_alert_rules/*' -type f -exec ./cos-tool-amd64 --format promql lint {} \;
+        run: find . -path '*/prometheus_alert_rules/*' -type f -exec ./cos-tool-amd64 --format promql lint {} +
       - name: Validate loki alert rules
-        run: find . -path '*/loki_alert_rules/*' -type f -exec ./cos-tool-amd64 --format logql lint {} \;
+        run: find . -path '*/loki_alert_rules/*' -type f -exec ./cos-tool-amd64 --format logql lint {} +

--- a/.github/workflows/_validate_rules.yaml
+++ b/.github/workflows/_validate_rules.yaml
@@ -1,0 +1,22 @@
+name: Validate rules
+
+on:
+  workflow_call: {}
+
+jobs:
+  rules:
+    name: Lint alert rules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Install dependencies
+        run: |
+          wget https://github.com/canonical/cos-tool/releases/download/rel-20220621/cos-tool-amd64
+          chmod +x ./cos-tool-amd64
+      - name: Validate prometheus alert rules
+        run: find . -path '*/prometheus_alert_rules/*' -type f -exec ./cos-tool-amd64 --format promql lint {} \;
+      - name: Validate loki alert rules
+        run: find . -path '*/loki_alert_rules/*' -type f -exec ./cos-tool-amd64 --format logql lint {} \;


### PR DESCRIPTION
This PR adds a workflow to automatically validate all alert rules in the repo.

## Breaking change
At the moment this would be a breaking change because cos-tool (or promtool) does not support our custom "one alert rule per file" format.

We could update cos-tool to automatically wrap such files with `groups:` before attempting validation or abandon the "one alert rule per file" format altogether. Or both, incrementally.

Fixes #12.