### PR TITLE
add optional charm-path in release_charm CI

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -1,7 +1,10 @@
 name: Integration Tests
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      charm-path:
+        required: false
 
 jobs:
   integration-test:
@@ -22,4 +25,4 @@ jobs:
         run: >
           sg microk8s -c "kubectl patch deployment hostpath-provisioner -n kube-system -p '{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\":\"hostpath-provisioner\", \"image\": \"cdkbot/hostpath-provisioner:1.3.0\" }] }}}}'"
       - name: Run integration tests
-        run: tox -vve integration
+        run: cd ${{ inputs.charm-path }} && tox -vve integration

--- a/.github/workflows/_linting.yaml
+++ b/.github/workflows/_linting.yaml
@@ -1,7 +1,10 @@
 name: Linting
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      charm-path:
+        required: false
 
 jobs:
   lint:
@@ -19,4 +22,4 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run linters
-        run: tox -vve lint
+        run: cd ${{ inputs.charm-path }} && tox -vve lint

--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -2,6 +2,9 @@ name: Pull Request
 
 on:
   workflow_call:
+    inputs:
+      charm-path:
+        required: false
     secrets:
       CHARMHUB_TOKEN:
         required: false
@@ -37,15 +40,22 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          charm-path: "${{ inputs.charm-path }}"
   static-analysis:
     name: Static Analysis
     uses: canonical/observability/.github/workflows/_static-analysis.yaml@main
+    with:
+      charm-path: "${{ inputs.charm-path }}"
   linting:
     name: Linting
     uses: canonical/observability/.github/workflows/_linting.yaml@main
+    with:
+      charm-path: "${{ inputs.charm-path }}"
   unit-test:
     name: Unit Tests
     uses: canonical/observability/.github/workflows/_unit-tests.yaml@main
+    with:
+      charm-path: "${{ inputs.charm-path }}"
   integration-test:
     name: Integration Tests
     needs:
@@ -53,3 +63,5 @@ jobs:
       - linting
       - unit-test
     uses: canonical/observability/.github/workflows/_integration-tests.yaml@main
+    with:
+      charm-path: "${{ inputs.charm-path }}"

--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -2,6 +2,12 @@ name: Release charm to Edge
 
 on:
   workflow_call:
+    inputs:
+      charm-path:
+        description: "Path to the charm we want to publish. Defaults to the current working directory."
+        default: '.'
+        required: false
+        type: string
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -24,3 +30,4 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
+          charm-path: "${{ inputs.charm-path }}"

--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -4,10 +4,7 @@ on:
   workflow_call:
     inputs:
       charm-path:
-        description: "Path to the charm we want to publish. Defaults to the current working directory."
-        default: '.'
         required: false
-        type: string
     secrets:
       CHARMHUB_TOKEN:
         required: true

--- a/.github/workflows/_static-analysis.yaml
+++ b/.github/workflows/_static-analysis.yaml
@@ -1,7 +1,10 @@
 name: Static Analysis
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      charm-path:
+        required: false
 
 jobs:
   static-lib:
@@ -19,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run static analysis for /lib for 3.5
-        run: tox -vve static-lib
+        run: cd ${{ inputs.charm-path }} && tox -vve static-lib
   static-charm:
     name: Static Analysis of Charm
     runs-on: ubuntu-latest
@@ -35,4 +38,4 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run static analysis (charm)
-        run: tox -vve static-charm
+        run: cd ${{ inputs.charm-path }} && tox -vve static-charm

--- a/.github/workflows/_unit-tests.yaml
+++ b/.github/workflows/_unit-tests.yaml
@@ -1,7 +1,10 @@
 name: Unit Tests
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      charm-path:
+        required: false
 
 jobs:
   unit-tests:
@@ -19,4 +22,4 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests
-        run: tox -e unit
+        run: cd ${{ inputs.charm-path }} && tox -e unit

--- a/.github/workflows/promote-charm.yaml
+++ b/.github/workflows/promote-charm.yaml
@@ -3,6 +3,10 @@ name: Promote Charm
 on:
   workflow_call:
     inputs:
+      charm-path:
+        type: string
+        default: '.'
+        required: false
       promotion:
         type: string
         required: true
@@ -34,6 +38,7 @@ jobs:
       - name: Promote Charm
         uses: canonical/charming-actions/release-charm@2.0.0
         with:
+          charm-path: ${{ inputs.charm-path }}
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: latest/${{ env.promote-to }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,6 +2,9 @@ name: Pull Request
 
 on:
   workflow_call:
+    inputs:
+      charm-path:
+        required: false
     secrets:
        CHARMHUB_TOKEN:
          required: false
@@ -10,3 +13,5 @@ jobs:
     name: Quality Checks
     uses: canonical/observability/.github/workflows/_quality-checks.yaml@main
     secrets: inherit
+    with:
+      charm-path: ${{ inputs.charm-path }}

--- a/.github/workflows/release-charm.yaml
+++ b/.github/workflows/release-charm.yaml
@@ -2,6 +2,12 @@ name: Release Charm
 
 on:
   workflow_call:
+    inputs:
+      charm-path:
+        description: "Path to the charm we want to publish. Defaults to the current working directory."
+        default: '.'
+        required: false
+        type: string
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -14,8 +20,12 @@ jobs:
   quality-checks:
     uses: canonical/observability/.github/workflows/_quality-checks.yaml@main
     secrets: inherit
+    with:
+      charm-path: "${{ inputs.charm-path }}"
   release-charm:
     needs: 
       - quality-checks
     uses: canonical/observability/.github/workflows/_release_charm.yaml@main
     secrets: inherit
+    with:
+      charm-path: "${{ inputs.charm-path }}"


### PR DESCRIPTION
## Issue

The release_charm CI currently assumes the charm will always be located in the repository root directory.  
However, this is not always true; as seen in https://github.com/canonical/catalogue-k8s-operator/issues/8, this assumption can cause the CI to break.

## Solution

Charming actions already support the `charm-path` parameter, as seen in the [action docs](https://github.com/canonical/charming-actions/tree/main/upload-charm); this PR allows specifying a different `charm-path`, while still assuming `.` as the default.