### PR TITLE
Update itest CI to use Juju 3

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -21,8 +21,7 @@ jobs:
         with:
           juju-channel: 3.0/stable
           provider: microk8s
-      - name: Patch hostpath-provisioner
-        run: >
-          sg microk8s -c "kubectl patch deployment hostpath-provisioner -n kube-system -p '{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\":\"hostpath-provisioner\", \"image\": \"cdkbot/hostpath-provisioner:1.3.0\" }] }}}}'"
+          channel: 1.25-strict/stable
+          bootstrap-options: "--agent-version 3.0.2"
       - name: Run integration tests
         run: cd ${{ inputs.charm-path }} && tox -vve integration

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -26,6 +26,5 @@ jobs:
           provider: microk8s
           channel: 1.25-strict/stable
           microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
-          bootstrap-options: "--agent-version 3.0.2"
       - name: Run integration tests
         run: cd ${{ inputs.charm-path }} && tox -vve integration

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -16,12 +16,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: Get prefsrc
+        run: |
+          echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.0/stable
           provider: microk8s
           channel: 1.25-strict/stable
+          microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
           bootstrap-options: "--agent-version 3.0.2"
       - name: Run integration tests
         run: cd ${{ inputs.charm-path }} && tox -vve integration


### PR DESCRIPTION
I've been running itests locally with juju 3.0.2 for a while and it seems stable.

- Version pin to microk8s 1.25-strict/stable, juju 3.0/stable
- Drop the hostpath patch (not needed anymore, as microk8s comes with `cdkbot/hostpath-provisioner:1.4.2`
- Enable metallb