### PR TITLE
allow using artifacts in the build

### DIFF
--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -26,12 +26,12 @@ jobs:
           fetch-depth: 1
       - name: Download Artifact
         uses: actions/download-artifact@v3
+        id: download_artifact
         with:
           name: "${{ inputs.artifact }}"
-          path: ./artifact.tar.gz
         if: ${{ inputs.artifact != '' }}
       - name: Unpack Artifact
-        run: sudo apt-get update && sudo apt-get install tar && tar xf artifact.tar.gz
+        run: sudo apt-get update && sudo apt-get install tar && tar xf ${{steps.download_artifact.outputs.download-path}}
         if: ${{ inputs.artifact != '' }}
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.1.1

--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         required: false
       artifacts:
-        description: "Json encoded list of artifacts to download before the build."
+        description: "Json encoded list of artifacts to download before the build in the format [[name, path],...]"
         default: "[]"
         required: false
         type: string
@@ -30,7 +30,8 @@ jobs:
           matrix:
             artifact-name: ${{ fromJson(inputs.artifacts) }}
         with:
-          name: "${{ matrix.artifact_name }}"
+          name: "${{ matrix.artifact_name[0] }}"
+          path: "${{ matrix.artifact_name[1] }}"
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.1.1
         id: channel

--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         required: false
       artifact:
-        description: "Name of artifact to download before building"
+        description: "Name of artifact to download before building. Should contain the file artifact.tar.gz."
         default: ''
         required: false
         type: string
@@ -31,7 +31,7 @@ jobs:
           name: "${{ inputs.artifact }}"
         if: ${{ inputs.artifact != '' }}
       - name: Unpack Artifact
-        run: sudo apt-get update && sudo apt-get install tar && tar xf ${{steps.download_artifact.outputs.download-path}}
+        run: sudo apt-get update && sudo apt-get install tar && tar xf artifact.tar.gz
         if: ${{ inputs.artifact != '' }}
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.1.1

--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -6,9 +6,9 @@ on:
       charm-path:
         type: string
         required: false
-      artifacts:
-        description: "Json encoded list of artifacts to download before the build in the format [[name, path],...]"
-        default: "[]"
+      artifact:
+        description: "Name of artifact to download before building"
+        default: ""
         required: false
         type: string
     secrets:
@@ -24,14 +24,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Download Artifacts
+      - name: Download Artifact
         uses: actions/download-artifact@v3
-        strategy:
-          matrix:
-            artifact-name: ${{ fromJson(inputs.artifacts) }}
         with:
-          name: "${{ matrix.artifact_name[0] }}"
-          path: "${{ matrix.artifact_name[1] }}"
+          name: "${{ inputs.artifact }}"
+          path: ./artifact.tar.gz
+      - name: Unpack Artifact
+        run: sudo apt-get update && sudo apt-get install tar && tar xf artifact.tar.gz
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.1.1
         id: channel

--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -8,7 +8,7 @@ on:
         required: false
       artifact:
         description: "Name of artifact to download before building"
-        default: ""
+        default: ''
         required: false
         type: string
     secrets:
@@ -29,10 +29,10 @@ jobs:
         with:
           name: "${{ inputs.artifact }}"
           path: ./artifact.tar.gz
-        if: ${{ inputs.artifact != "" }}
+        if: ${{ inputs.artifact != '' }}
       - name: Unpack Artifact
         run: sudo apt-get update && sudo apt-get install tar && tar xf artifact.tar.gz
-        if: ${{ inputs.artifact != "" }}
+        if: ${{ inputs.artifact != '' }}
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.1.1
         id: channel

--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -29,8 +29,10 @@ jobs:
         with:
           name: "${{ inputs.artifact }}"
           path: ./artifact.tar.gz
+        if: ${{ inputs.artifact != "" }}
       - name: Unpack Artifact
         run: sudo apt-get update && sudo apt-get install tar && tar xf artifact.tar.gz
+        if: ${{ inputs.artifact != "" }}
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.1.1
         id: channel

--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         required: false
       artifact:
-        description: "Name of artifact to download before building. Should contain the file artifact.tar.gz."
+        description: "Name of artifact to download before building. Must contain the file artifact.tar.gz."
         default: ''
         required: false
         type: string

--- a/.github/workflows/_release_charm.yaml
+++ b/.github/workflows/_release_charm.yaml
@@ -6,6 +6,11 @@ on:
       charm-path:
         type: string
         required: false
+      artifacts:
+        description: "Json encoded list of artifacts to download before the build."
+        default: "[]"
+        required: false
+        type: string
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -19,6 +24,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        strategy:
+          matrix:
+            artifact-name: ${{ fromJson(inputs.artifacts) }}
+        with:
+          name: "${{ matrix.artifact_name }}"
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.1.1
         id: channel

--- a/.github/workflows/release-charm.yaml
+++ b/.github/workflows/release-charm.yaml
@@ -8,9 +8,9 @@ on:
         default: '.'
         required: false
         type: string
-      artifacts:
-        description: "Json encoded list of artifacts to download before the build in the format [[name, path],...]"
-        default: "[]"
+      artifact:
+        description: "Name of artifact to download before building"
+        default: ""
         required: false
         type: string
     secrets:

--- a/.github/workflows/release-charm.yaml
+++ b/.github/workflows/release-charm.yaml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       artifact:
-        description: "Name of artifact to download before building"
+        description: "Name of artifact to download before building. Should contain the file artifact.tar.gz."
         default: ''
         required: false
         type: string

--- a/.github/workflows/release-charm.yaml
+++ b/.github/workflows/release-charm.yaml
@@ -30,7 +30,7 @@ jobs:
   release-charm:
     needs: 
       - quality-checks
-    uses: canonical/observability/.github/workflows/_release_charm.yaml@artifacts
+    uses: ./.github/workflows/_release_charm.yaml
     secrets: inherit
     with:
       artifact: "${{ inputs.artifact }}"

--- a/.github/workflows/release-charm.yaml
+++ b/.github/workflows/release-charm.yaml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       artifacts:
-        description: "Json encoded list of artifacts to download before the build."
+        description: "Json encoded list of artifacts to download before the build in the format [[name, path],...]"
         default: "[]"
         required: false
         type: string

--- a/.github/workflows/release-charm.yaml
+++ b/.github/workflows/release-charm.yaml
@@ -30,7 +30,7 @@ jobs:
   release-charm:
     needs: 
       - quality-checks
-    uses: canonical/observability/.github/workflows/_release_charm.yaml@main
+    uses: canonical/observability/.github/workflows/_release_charm.yaml@artifacts
     secrets: inherit
     with:
       artifact: "${{ inputs.artifact }}"

--- a/.github/workflows/release-charm.yaml
+++ b/.github/workflows/release-charm.yaml
@@ -10,7 +10,7 @@ on:
         type: string
       artifact:
         description: "Name of artifact to download before building"
-        default: ""
+        default: ''
         required: false
         type: string
     secrets:

--- a/.github/workflows/release-charm.yaml
+++ b/.github/workflows/release-charm.yaml
@@ -8,6 +8,11 @@ on:
         default: '.'
         required: false
         type: string
+      artifacts:
+        description: "Json encoded list of artifacts to download before the build."
+        default: "[]"
+        required: false
+        type: string
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -28,4 +33,5 @@ jobs:
     uses: canonical/observability/.github/workflows/_release_charm.yaml@main
     secrets: inherit
     with:
+      artifacts: "${{ inputs.artifacts }}"
       charm-path: "${{ inputs.charm-path }}"

--- a/.github/workflows/release-charm.yaml
+++ b/.github/workflows/release-charm.yaml
@@ -33,5 +33,5 @@ jobs:
     uses: canonical/observability/.github/workflows/_release_charm.yaml@main
     secrets: inherit
     with:
-      artifacts: "${{ inputs.artifacts }}"
+      artifact: "${{ inputs.artifact }}"
       charm-path: "${{ inputs.charm-path }}"

--- a/.github/workflows/release-charm.yaml
+++ b/.github/workflows/release-charm.yaml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       artifact:
-        description: "Name of artifact to download before building. Should contain the file artifact.tar.gz."
+        description: "Name of artifact to download before building. Must contain the file artifact.tar.gz."
         default: ''
         required: false
         type: string


### PR DESCRIPTION
We need to allow uploading of artifacts so that if there are special build steps for a charm, the results of those steps can be included in the final build.

In particular, the Grafana Agent charm needs to render some platform specific files.