### PR TITLE
Add missing quotation mark

### DIFF
--- a/.github/workflows/update-rock.yaml
+++ b/.github/workflows/update-rock.yaml
@@ -79,7 +79,7 @@ jobs:
         run: |
           source_tag="${{ steps.check.outputs.release }}"
           version=${source_tag#"v"}
-          yq -i '.version = strenv(version) | .parts.${{ inputs.rock-name }}["source-tag] = strenv(source_tag)' $GITHUB_WORKSPACE/main/rockcraft.yaml
+          yq -i '.version = strenv(version) | .parts.${{ inputs.rock-name }}["source-tag"] = strenv(source_tag)' $GITHUB_WORKSPACE/main/rockcraft.yaml
 
       - name: Create a PR
         if: ${{ steps.check.outputs.release != '' }}


### PR DESCRIPTION
Alertmanager CI [failed](https://github.com/canonical/alertmanager-rock/actions/runs/4234566185/jobs/7357033272) with:
```
  source_tag="v0.25.0"
  version=${source_tag#"v"}
  yq -i '.version = strenv(version) | .parts.alertmanager["source-tag] = strenv(source_tag)' $GITHUB_WORKSPACE/main/rockcraft.yaml
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
Error: 1:50: invalid input text "\"source-tag] = s..."
```
Add missing quote per suggestion by @lucabello.