### PR TITLE
Use Juju 3.1 (from edge for now) for CI

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -22,8 +22,10 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: latest/stable
+          juju-channel: 3.1/edge
           provider: microk8s
+          channel: 1.26-strict/stable
+          microk8s-group: snap_microk8s
           microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
       - name: Run integration tests
         run: cd ${{ inputs.charm-path }} && tox -vve integration


### PR DESCRIPTION
Use Juju 3.1 (less changes than 2.9.42) from edge to resolve the unit termination issue and allow CI to pass.