### PR TITLE
Replace community action with the GitHub API

### DIFF
--- a/.github/workflows/update-rock.yaml
+++ b/.github/workflows/update-rock.yaml
@@ -32,13 +32,17 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          sudo snap install jq
           sudo snap install yq
-
       - id: latest-release
-        uses: pozetroninc/github-action-get-latest-release@v0.6.0
-        with:
-          repository: ${{ inputs.source-repo }}
-          excludes: prerelease, draft
+        run: |
+          export TAG=curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ inputs.source-repo}}/releases/latest \
+            | jq .tag_name
+          echo "release=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout the ROCK source
         uses: actions/checkout@v3


### PR DESCRIPTION
This is needed as some repositories issue releases in a non-deterministic orders. However, so far all of the maintainers have stuck to using the `latest` tag correctly. The prior action did not take this into account.

Since this is a CI change, it is untested in a workflow but works when I run the curl request locally.