### PR TITLE
Skip empty lines in 'get pods' output

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -46,4 +46,4 @@ jobs:
         shell: bash
         run: |
           juju status --relations --storage
-          kubectl get pods -A -o=jsonpath='{range.items[*]}{.metadata.namespace} {.metadata.name}{"\n"}' --sort-by=.metadata.namespace | while read namespace pod; do kubectl -n $namespace describe pod $pod; kubectl -n $namespace logs $pod --all-containers=true --tail=100; done
+          kubectl get pods -A -o=jsonpath='{range.items[*]}{.metadata.namespace} {.metadata.name}{"\n"}' --sort-by=.metadata.namespace | grep -v "^\s*$" | while read namespace pod; do kubectl -n $namespace describe pod $pod; kubectl -n $namespace logs $pod --all-containers=true --tail=100; done


### PR DESCRIPTION
## Problem
Before this change, the log dump tasks [fails](https://github.com/canonical/traefik-k8s-operator/actions/runs/4473204768/jobs/7860338839#step:9:1751) with
```
Error: flags cannot be placed before plugin name: -n
Error: Process completed with exit code 1.
```
because the last line of output from `-o=jsonpath='{range.items[*]}{.metadata.namespace} {.metadata.name}{"\n"}'` is a blank line.

![image](https://user-images.githubusercontent.com/82407168/226507876-cd76adb4-2df9-4b02-9ec4-5973a95e620a.png)

## Solution
Filter out blank lines.