### PR TITLE
Dump debug log too

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -29,6 +29,9 @@ jobs:
           microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
       - name: Run integration tests
         run: cd ${{ inputs.charm-path }} && tox -vve integration
+      - name: Dump debug log
+        if: failure()
+        run: juju debug-log --replay
       - name: Dump charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Problem
In failures such as [this](https://github.com/canonical/cos-lite-bundle/actions/runs/4532418091/jobs/7983763586) we still don't know the nature of the failure -- need to see Tracebacks.

## Solution
Also dump debug log. It is slightly racy with pytest-operator destroying the model but still better than nothing, probably?