### PR TITLE
skip CI quality checks for non-source files

### DIFF
--- a/.ciignore
+++ b/.ciignore
@@ -4,6 +4,7 @@
 .github/**/*
 
 
+.ciignore
 .gitignore
 CODEOWNERS
 LICENSE

--- a/.ciignore
+++ b/.ciignore
@@ -1,0 +1,10 @@
+**/*.md
+.**/*.md
+
+.github/**/*
+
+
+.gitignore
+CODEOWNERS
+LICENSE
+icon.svg

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,8 +12,38 @@ on:
        CHARMHUB_TOKEN:
          required: false
 jobs:
+  ci-ignore:
+    name: Check against ignorelist
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.diff.outputs.files }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Expand ignorelist
+        shell: bash
+        run: |
+          test -f .ciignore || wget https://raw.githubusercontent.com/canonical/observability/main/.ciignore
+          while IFS= read -r globline; do
+            compgen -G "$globline" >> .ciignore-expanded
+          done < .ciignore
+          sed -i '/^$/d' .ciignore-expanded
+      - name: Generate diff
+        id: diff
+        shell: bash
+        run: |
+          base="remotes/origin/${{ github.base_ref }}"
+          head="remotes/origin/${{ github.head_ref }}"
+          echo "Comparing $base to $head"
+          files=$(comm -23 <(git diff --name-only $base $head | sort) <(sort .ciignore-expanded))
+          echo "$files"
+          echo "files=$files" | tr -d '\n' >> $GITHUB_OUTPUT
   quality-checks:
     name: Quality Checks
+    needs:
+      - ci-ignore
+    if: ${{ needs.ci-ignore.outputs.files != '' }}
     uses: canonical/observability/.github/workflows/_quality-checks.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,9 +26,9 @@ jobs:
         run: |
           test -f .ciignore || wget https://raw.githubusercontent.com/canonical/observability/main/.ciignore
           while IFS= read -r globline; do
-            compgen -G "$globline" >> .ciignore-expanded
+            compgen -G "$globline" >> .ciignore
           done < .ciignore
-          sed -i '/^$/d' .ciignore-expanded
+          sed -i '/^$/d'
       - name: Generate diff
         id: diff
         shell: bash
@@ -36,7 +36,7 @@ jobs:
           base="remotes/origin/${{ github.base_ref }}"
           head="remotes/origin/${{ github.head_ref }}"
           echo "Comparing $base to $head"
-          files=$(comm -23 <(git diff --name-only $base $head | sort) <(sort .ciignore-expanded))
+          files=$(comm -23 <(git diff --name-only $base $head | sort) <(sort .ciignore))
           echo "$files"
           echo "files=$files" | tr -d '\n' >> $GITHUB_OUTPUT
   quality-checks:


### PR DESCRIPTION
This PR expands on https://github.com/canonical/alertmanager-k8s-operator/pull/126 and implements the CI skip feature in our central repo.

The glob functionality is achieved through `compgen`, which expands the `.ciignore` file and allows for the full comparison.

Note that each repo can specify its own `.ciignore` file; if not, the latest one in this repo will be used as a default.