### PR TITLE
update canonical/setup-lxd to v0.1.1

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup LXD
-      uses: canonical/setup-lxd@v0.1.0
+      uses: canonical/setup-lxd@v0.1.1
       with:
         channel: latest/stable
 


### PR DESCRIPTION
There is a bug in canonical/setup-lxd@v0.1.0 where the `channel` input is ignored. This has been fixed in v0.1.1. See https://github.com/canonical/setup-lxd/pull/8