### PR TITLE
ci: add new rocks workflows for the oci-factory procedures

### DIFF
--- a/.github/workflows/_rock-build-test.yaml
+++ b/.github/workflows/_rock-build-test.yaml
@@ -1,0 +1,34 @@
+name: Build ROCK
+
+on:
+  workflow_call:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup LXD
+      uses: canonical/setup-lxd@v0.1.0
+      with:
+        channel: latest/stable
+
+    - name: Install dependencies
+      run: |
+        sudo snap install yq
+        sudo snap install --classic --channel edge rockcraft
+
+    - name: Determine the rockcraft.yaml changed in the PR
+      id: changed-files
+      uses: tj-actions/changed-files@v35
+      with:
+        files: **/rockcraft.yaml
+
+    - name: Build ROCK
+      if: steps.changed-files.outputs.any_changed
+      run: |
+        for file in ${{ steps.changed-files.outputs.changed_files }}; do
+          rockcraft pack "$file" --verbose #TODO: check this is the way to pass a path to rockraft pack
+        done

--- a/.github/workflows/_rock-build-test.yaml
+++ b/.github/workflows/_rock-build-test.yaml
@@ -15,20 +15,22 @@ jobs:
       with:
         channel: latest/stable
 
-    - name: Install dependencies
-      run: |
-        sudo snap install yq
-        sudo snap install --classic --channel edge rockcraft
-
-    - name: Determine the rockcraft.yaml changed in the PR
+    - name: Determine any rockcraft.yaml changed in the PR
       id: changed-files
       uses: tj-actions/changed-files@v35
       with:
         files: "**/rockcraft.yaml"
 
+    - name: Install dependencies
+      if: steps.changed-files.outputs.any_changed
+      run: |
+        sudo snap install --classic --channel edge rockcraft
+
     - name: Build ROCK
       if: steps.changed-files.outputs.any_changed
       run: |
         for file in ${{ steps.changed-files.outputs.changed_files }}; do
-          rockcraft pack "$file" --verbose #TODO: check this is the way to pass a path to rockraft pack
+          current_wd=$(pwd) && cd ${file%/*}
+          rockcraft pack
+          cd $current_wd
         done

--- a/.github/workflows/_rock-build-test.yaml
+++ b/.github/workflows/_rock-build-test.yaml
@@ -24,7 +24,7 @@ jobs:
       id: changed-files
       uses: tj-actions/changed-files@v35
       with:
-        files: **/rockcraft.yaml
+        files: "**/rockcraft.yaml"
 
     - name: Build ROCK
       if: steps.changed-files.outputs.any_changed

--- a/.github/workflows/_rock-build-test.yaml
+++ b/.github/workflows/_rock-build-test.yaml
@@ -10,16 +10,17 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Setup LXD
-      uses: canonical/setup-lxd@v0.1.0
-      with:
-        channel: latest/stable
-
     - name: Determine any rockcraft.yaml changed in the PR
       id: changed-files
       uses: tj-actions/changed-files@v35
       with:
         files: "**/rockcraft.yaml"
+
+    - name: Setup LXD
+      if: steps.changed-files.outputs.any_changed
+      uses: canonical/setup-lxd@v0.1.0
+      with:
+        channel: latest/stable
 
     - name: Install dependencies
       if: steps.changed-files.outputs.any_changed

--- a/.github/workflows/_rock-build-test.yaml
+++ b/.github/workflows/_rock-build-test.yaml
@@ -1,4 +1,4 @@
-name: Build ROCK
+name: Build ROCKs
 
 on:
   workflow_call:

--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -6,4 +6,4 @@ on:
 jobs:
   test-build:
     name: Test ROCK build
-    uses: canonical/observability/.github/workflows/_rock-build-test.yaml
+    uses: canonical/observability/.github/workflows/_rock-build-test.yaml@main

--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -1,4 +1,5 @@
 name: Pull Request
+# quality checks to make sure the change won't break things
 
 on:
   workflow_call:

--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -1,0 +1,9 @@
+name: Pull Request
+
+on:
+  workflow_call:
+
+jobs:
+  test-build:
+    name: Test ROCK build
+    uses: canonical/observability/.github/workflows/_rock-build-test.yaml

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -1,3 +1,4 @@
+# This action automatically creates a folder with the same name as the upstream version
 name: Update ROCK on new releases of its source
 
 concurrency:
@@ -65,8 +66,7 @@ jobs:
             echo "No new upstream release found"
           fi
 
-      - id: check-go-version
-        name: Checkout application source for the Go version check
+      - name: Checkout application source for the Go version check
         if: ${{ inputs.check-go }} && ${{ steps.check.outputs.release != '' }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -80,6 +80,7 @@ jobs:
         run: |
           source_tag="${{ steps.check.outputs.release }}"
           version="${{ steps.check.outputs.version }}"
+          mkdir $GITHUB_WORKSPACE/main/$version
           latest_rockcraft_file=$(find $GITHUB_WORKSPACE/main/ -name "rockcraft.yaml" | sort -V | tail -n1)
           cp "$latest_rockcraft_file" "$GITHUB_WORKSPACE/main/$version/rockcraft.yaml"
           source_tag="$source_tag" \

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -1,0 +1,109 @@
+name: Update ROCK on new releases of its source
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+    inputs:
+      rock-name:
+        description: "Name of the application for which to build the ROCK"
+        required: true
+        type: string
+      source-repo:
+        description: "Repository of the source application in 'org/repo' form"
+        required: true
+        type: string
+      check-go: 
+        description: "Flag to check updates on the Go version"
+        default: false
+        required: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-version:
+    name: Detect new releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo snap install jq
+          sudo snap install yq
+
+      - id: latest-release
+        name: Fetch version used in *latest* release
+        run: |
+          TAG=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ inputs.source-repo }}/releases/latest \
+            | jq -r .tag_name)
+          echo "release=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout the ROCK source
+        uses: actions/checkout@v3
+        with:
+          path: main
+
+      - id: check
+        name: Check if the release has already been added
+        shell: bash
+        run: |
+          source_tag="${{ steps.check.outputs.release }}"
+          version=${source_tag#"v"}
+          if [ ! -f /$version/rockcraft.yaml ]; then
+            echo "version=$version" >> $GITHUB_OUTPUT
+            echo "release=${{steps.latest-release.outputs.release}}" >> $GITHUB_OUTPUT
+            echo "New upstream release ${{steps.latest-release.outputs.release}} found"
+          else
+            echo "No new upstream release found"
+          fi
+
+      - id: check-go-version
+        name: Checkout application source for the Go version check
+        if: ${{ inputs.check-go }} && ${{ steps.check.outputs.release != '' }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.source-repo }}
+          ref: ${{ steps.check.outputs.release }}
+          path: application-src
+      
+      - name: Create a new rockcraft.yaml for the new application version
+        if: ${{ steps.check.outputs.release != '' }}
+        shell: bash
+        run: |
+          source_tag="${{ steps.check.outputs.release }}"
+          version="${{ steps.check.outputs.version }}"
+          latest_rockcraft_file=$(find $GITHUB_WORKSPACE/main/ -name "rockcraft.yaml" | sort -V | tail -n1)
+          cp "$latest_rockcraft_file" "$GITHUB_WORKSPACE/main/$version/rockcraft.yaml"
+          source_tag="$source_tag" \
+          version="$version" \
+          yq -i '.version = strenv(version) | .parts.${{ inputs.rock-name }}["source-tag"] = strenv(source_tag)' $GITHUB_WORKSPACE/main/$version/rockcraft.yaml
+
+      - name: Update the Go version
+        if: ${{ inputs.check-go }} && ${{ steps.check.outputs.release != '' }}
+        shell: bash
+        run: |
+          version="${{ steps.check.outputs.version }}"
+          go_version=$(grep -Po "^go \K(\S+)" $GITHUB_WORKSPACE/application-src/go.mod) \
+          yq -i '.parts.${{ inputs.rock-name }}["build-snaps"] = ["go/" + strenv(go_version) + "/stable"]' $GITHUB_WORKSPACE/main/$version/rockcraft.yaml
+
+      - name: Create a PR
+        if: ${{ steps.check.outputs.release != '' }}
+        uses: peter-evans/create-pull-request@v4.2.3
+        with:
+          path: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(deps): bump ${{ inputs.rock-name }} version to ${{ steps.check.outputs.release }}"
+          committer: "Github Actions <github-actions@github.com>"
+          author: "Github Actions <github-actions@github.com>"
+          title: "chore: add ROCK for ${{ inputs.rock-name }} ${{ steps.check.outputs.release }}"
+          body: Automated update to follow upstream [release](https://github.com/${{ inputs.source-repo }}/releases/tag/${{ steps.check.outputs.release }}) of ${{ inputs.rock-name }}.
+          branch: "chore/bump-version-to-${{ steps.check.outputs.release }}"
+          delete-branch: true


### PR DESCRIPTION
The current ROCKs workflows need to be adapted for the **oci-factory** story.

The changes in this PR include two callable workflows:
* **rock-update.yaml**, which (just as the previous version) pulls the latest GitHub release from the upstream project, opening a PR when a new version is found
  the main difference is that instead of replacing the *rockcraft.yaml* file, a new folder will be created for that upstream version; allowing us to apply security patches to all the versions we are maintaining
* **rock-pull-request.yaml**, which runs quality checks to make sure the change won't break things; currently, this is simply trying to pack the ROCK, but it can easily be expanded in the future

This is a first step needed for https://github.com/canonical/prometheus-rock/issues/12.

---

As shown in https://github.com/canonical/prometheus-rock/pull/11, the current `rock-update.yaml` workflow will remove any other **go** dependency besides **go** itself. For Prometheus specifically, the _webui_ needs the node dependency, as shown in the related [package.json](https://github.com/prometheus/prometheus/blob/main/web/ui/package.json) file. The CI should look for dependencies in these files as well and add them to the `rockcraft.yaml` if relevant.