### PR TITLE
Remove inclusive naming check

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -20,11 +20,6 @@ jobs:
           CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
         if: "${{ env.CHARMHUB_TOKEN != '' }}"
         run: echo "defined=true" >> $GITHUB_OUTPUT
-  call-inclusive-naming-check:
-    name: Inclusive naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
-    with:
-      fail-on-error: "true"
   lib-check:
     name: Check libraries
     runs-on: ubuntu-latest


### PR DESCRIPTION
The inclusive naming check has usability issues:
- The action takes a root dir only and [does not take exclusions](https://github.com/canonical/Inclusive-naming/issues/12). In order to exclude vendored charmlibs from the check, we would need to jump through some hoops. Different hoops for different repos. Or [try to force](https://github.com/canonical/mutual-tls-interface/pull/3) the vendored libs to use the same CI we do.
- The underlying `woke` tool has [false positives](https://github.com/get-woke/woke/issues/272) for URLs, requiring us to do ridiculous edits such as [this](https://github.com/canonical/traefik-k8s-operator/pull/207/commits/b9ca3295198d3f92e55dfff3583edc0952e43867).

We can add this check back in a separate PR that runs periodically, separate from the PR process.