### PR TITLE
fix rock dev release workflow

### DIFF
--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Find the *latest* rockcraft.yaml
       id: find-latest
       run: |
-        latest_rockcraft_file=$(find $GITHUB_WORKSPACE/main/ -name "rockcraft.yaml" | sort -V | tail -n1)
+        latest_rockcraft_file=$(find $GITHUB_WORKSPACE -name "rockcraft.yaml" | sort -V | tail -n1)
         rockcraft_dir=$(dirname ${latest_rockcraft_file#\./})
         echo "latest-dir=$rockcraft_dir" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
```
find: ‘/home/runner/work/prometheus-rock/prometheus-rock/main/’: No such file or directory
```
It looks like the repo is actually in `prometheus-rock/prometheus-rock`, without the `main` folder.