### PR TITLE
run _charm-release on 22.04

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   release-to-charmhub:
     name: Release to CharmHub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR should solve the CI failures when building charms on 22.04, which we need for [tempo-k8s-operator](https://github.com/canonical/tempo-k8s-operator/actions/runs/5863836937/job/15898106785).

This should still allow other charms to pack on 20.04.

---

**If this breaks the release of other charms** this PR should be reverted, and one more input should be added to the workflow to set the `runs-on` property (with a default value of `20.04`, and Tempo setting `22.04`).