### PR TITLE
fix rock-update CI for mimir

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -62,6 +62,8 @@ jobs:
         run: |
           source_tag="${{ steps.latest-release.outputs.release }}"
           version=${source_tag#"v"}
+          # Explicitly filter for specific ROCKs because we'd rather notice if a new ROCK has a different release schema
+          version=${source_tag#"mimir-"}
           if [ ! -f $GITHUB_WORKSPACE/main/$version/rockcraft.yaml ]; then
             echo "version=$version" >> $GITHUB_OUTPUT
             echo "release=${{steps.latest-release.outputs.release}}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Mimir has a different release schema, tagging things as `mimir-x.y.z`.

I intentionally made the filter not generic to be able to catch different release schemas in new ROCKs (we will notice in the PR); otherwise the ROCK might not be compatible with the structure we're using for oci-factory.