### PR TITLE
fix rock-update to copy the folder instead of rockcraft only

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -88,7 +88,7 @@ jobs:
           version="${{ steps.check.outputs.version }}"
           mkdir $GITHUB_WORKSPACE/main/$version
           latest_rockcraft_file=$(find $GITHUB_WORKSPACE/main/ -name "rockcraft.yaml" | sort -V | tail -n1)
-          cp "$latest_rockcraft_file" "$GITHUB_WORKSPACE/main/$version/rockcraft.yaml"
+          cp -r "$(dirname $latest_rockcraft_file)" "$GITHUB_WORKSPACE/main/$version"
           source_tag="$source_tag" \
           version="$version" \
           yq -i '.version = strenv(version) | .parts.${{ inputs.rock-name }}["source-tag"] = strenv(source_tag)' $GITHUB_WORKSPACE/main/$version/rockcraft.yaml


### PR DESCRIPTION
ROCK Update should generate the new version folder by copying the latest version folder, not file, so that we also bundle whatever file is uesd in `rockcraft.yaml`