### PR TITLE
Do not use destructive mode

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -43,3 +43,6 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
           charm-path: "${{ inputs.charm-path }}"
+          # We set destructive mode to false, otherwise runner's OS would have to match
+          # charm's 'build-on' OS.
+          destructive-mode: false


### PR DESCRIPTION
This PR disables destructive mode in order to decouple runner OS from charm's build-on OS.
https://github.com/canonical/observability/pull/90#issuecomment-1682767013