### PR TITLE
Bump upload-charm to v2.4.0

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: canonical/charming-actions/channel@2.1.1
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.1.1
+        uses: canonical/charming-actions/upload-charm@2.4.0
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
#95 added an arg that did not exist in v2.1.1, so [CI failed](https://github.com/canonical/traefik-k8s-operator/actions/runs/5896527375/job/15995263594):
```
Warning: Unexpected input(s) 'destructive-mode', valid inputs are ['channel', 'tag-prefix', 'charm-path', 'charmcraft-channel', 'upload-image', 'credentials', 'github-token', 'resource-overrides']
```

Bumping to latest.