### PR TITLE
setup lxd in charm release

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/stable
       - name: Download Artifact
         uses: actions/download-artifact@v3
         id: download_artifact


### PR DESCRIPTION
We're now running charmcraft in non-destructive mode, so we now need to setup LXD to pack charms.