### PR TITLE
fix finding the latest version in rock-update

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -87,7 +87,6 @@ jobs:
         run: |
           source_tag="${{ steps.check.outputs.release }}"
           version="${{ steps.check.outputs.version }}"
-          mkdir $GITHUB_WORKSPACE/main/$version
           latest_rockcraft_file=$(find $GITHUB_WORKSPACE/main/ -name "rockcraft.yaml" | sort -V | tail -n1)
           cp -r "$(dirname $latest_rockcraft_file)" "$GITHUB_WORKSPACE/main/$version"
           source_tag="$source_tag" \


### PR DESCRIPTION
Running `mkdir` before finding the `latest_rockcraft_file` causes the newly created dir to be selected instead of the latest **before** the dir is created. The directory will always be empty and the CI will fail.

The `mkdir` command can be removed altogether as the entire folder is copied with the following `cp -r` anyway.