### PR TITLE
fix ignorelist ci action version

### DIFF
--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Determine changed files in the PR
         id: changed-files
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v38
         with:
           files_ignore_yaml: |
             docs:


### PR DESCRIPTION
Apparently `files_ignore_yaml` doesn't exist until version 36 :) This PR bumps the version of the action so that it supports that input parameter.