### PR TITLE
Prevent logging steps from failing

### DIFF
--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -55,12 +55,6 @@ jobs:
                       --tail=100; \
                done
           exit 0
-      - name: Dump charmcraft logs
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: charmcraft-logs
-          path: ~/.local/state/charmcraft/log/*.log
       - name: Dump deployments
         if: failure()
         run: |
@@ -71,3 +65,9 @@ jobs:
         run: |
           kubectl describe replicasets -A
           exit 0
+      - name: Dump charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: charmcraft-logs
+          path: ~/.local/state/charmcraft/log/*.log

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -36,11 +36,11 @@ jobs:
         run: cd ${{ inputs.charm-path }} && tox -vve integration
       - name: Dump debug log
         if: failure()
-        continue-on-error: true
-        run: for m in $(juju models --format json | jq -r '.models[].name' | grep -v "admin/controller"); do juju debug-log -m $m --replay --ms --no-tail; done
+        run: |
+          for m in $(juju models --format json | jq -r '.models[].name' | grep -v "admin/controller"); do juju debug-log -m $m --replay --ms --no-tail; done
+          exit 0
       - name: Dump pods and their logs
         if: failure()
-        continue-on-error: true
         run: |
           juju status --relations --storage
           kubectl get pods \
@@ -54,18 +54,20 @@ jobs:
                       --all-containers=true \
                       --tail=100; \
                done
+          exit 0
       - name: Dump charmcraft logs
         if: failure()
-        continue-on-error: true
         uses: actions/upload-artifact@v3
         with:
           name: charmcraft-logs
           path: ~/.local/state/charmcraft/log/*.log
       - name: Dump deployments
         if: failure()
-        continue-on-error: true
-        run: kubectl describe deployments -A
+        run: |
+          kubectl describe deployments -A
+          exit 0
       - name: Dump replicasets
         if: failure()
-        continue-on-error: true
-        run: kubectl describe replicasets -A
+        run: |
+          kubectl describe replicasets -A
+          exit 0

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -7,6 +7,11 @@ on:
         type: string
         required: false
 
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
 jobs:
   integration-test:
     name: Integration Tests
@@ -31,23 +36,11 @@ jobs:
         run: cd ${{ inputs.charm-path }} && tox -vve integration
       - name: Dump debug log
         if: failure()
+        continue-on-error: true
         run: for m in $(juju models --format json | jq -r '.models[].name' | grep -v "admin/controller"); do juju debug-log -m $m --replay --ms --no-tail; done
-        shell: bash
-      - name: Dump charmcraft logs
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: charmcraft-logs
-          path: ~/.local/state/charmcraft/log/*.log
-      - name: Dump deployments
-        if: failure()
-        run: kubectl describe deployments -A
-      - name: Dump replicasets
-        if: failure()
-        run: kubectl describe replicasets -A
       - name: Dump pods and their logs
         if: failure()
-        shell: bash
+        continue-on-error: true
         run: |
           juju status --relations --storage
           kubectl get pods \
@@ -61,3 +54,18 @@ jobs:
                       --all-containers=true \
                       --tail=100; \
                done
+      - name: Dump charmcraft logs
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: charmcraft-logs
+          path: ~/.local/state/charmcraft/log/*.log
+      - name: Dump deployments
+        if: failure()
+        continue-on-error: true
+        run: kubectl describe deployments -A
+      - name: Dump replicasets
+        if: failure()
+        continue-on-error: true
+        run: kubectl describe replicasets -A


### PR DESCRIPTION
## Problem
When logging fails, it steals the focus, and then we need to go all the way up again.
![image](https://github.com/canonical/observability/assets/82407168/23e99376-bf21-4bb9-9910-3d95edbd1ae0)
https://github.com/canonical/grafana-agent-k8s-operator/actions/runs/6100179604/job/16554281882

## Solution
1. Consider logging steps as "passed" even if they failed, using "exit 0".
2. Move one of the steps higher up so it has more chance to complete before teardown.