### PR TITLE
fix charm-release workflow call

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -35,7 +35,7 @@ jobs:
       - quality-checks
     steps:
       - name: Release Charm
-        uses: ./.github/workflows/_charm-release.yaml
+        uses: canonical/observability/.github/workflows/_charm-release.yaml@main
         with:
           artifact: "${{ inputs.artifact }}"
           charm-path: "${{ inputs.charm-path }}"


### PR DESCRIPTION
The relative path will look for a workflow in the repository of the **caller**, not on this repo; this PR fixes that behavior.