### PR TITLE
add support for lxd provider in integration tests for machine charms

### DIFF
--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -6,6 +6,10 @@ on:
       charm-path:
         type: string
         required: false
+      provider:
+        type: string
+        description: "The provider to choose for either machine or k8s tests ('lxd' or 'microk8s')"
+        default: microk8s
 
 # Default to bash
 defaults:
@@ -24,7 +28,14 @@ jobs:
       - name: Get prefsrc
         run: |
           echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV
-      - name: Setup operator environment
+      - name: Setup operator enviroment (machine)
+        if: inputs.provider == "lxd"
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: 3.1/edge
+          provider: lxd
+      - name: Setup operator environment (k8s)
+        if: inputs.provider == "microk8s"
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.1/edge


### PR DESCRIPTION
## Issue

Closes #108.

## Solution

@sed-i note that "merging" the two steps into one isn't possible due to the different parameters passed to the microk8s one (e.g., the channel).

This PR will execute only the setup step indicated by the `inputs.provider` variable, and skip the other; defaulting to `provider: microk8s` should make the change transparent to our other repos :)