### PR TITLE
fix: itests ci workflow syntax

### DIFF
--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -29,13 +29,13 @@ jobs:
         run: |
           echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV
       - name: Setup operator enviroment (machine)
-        if: inputs.provider == "lxd"
+        if: inputs.provider == 'lxd'
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.1/edge
           provider: lxd
       - name: Setup operator environment (k8s)
-        if: inputs.provider == "microk8s"
+        if: inputs.provider == 'microk8s'
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.1/edge


### PR DESCRIPTION
Workflows fail with:

```
The workflow is not valid. 
In canonical/observability/.github/workflows/_quality-checks.yaml@main (Line: 72, Col: 11):
  Error from called workflow canonical/observability/.github/workflows/_charm-tests-integration.yaml@main (Line: 32, Col: 13):
    Unexpected symbol: '"lxd"'. Located at position 20 within expression: inputs.provider == "lxd"
canonical/observability/.github/workflows/_charm-tests-integration.yaml@main (Line: 38, Col: 13):
    Unexpected symbol: '"microk8s"'. Located at position 20 within expression: inputs.provider == "microk8s"
```

According to [the official docs](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository), using single quotes should work.

