### PR TITLE
fix: add NOCTUA token as a required secret

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -21,6 +21,8 @@ on:
     secrets:
       CHARMHUB_TOKEN:
         required: true
+      OBSERVABILITY_NOCTUA_TOKEN:
+        required: true
 
 concurrency:
   group: release


### PR DESCRIPTION
## Issue

This is an attempt at fixing #116.

## Solution

Since `release-libraries.yaml` succeeds, and `charm-release.yaml` fails, I'm trying to bridge the gap between the two by adding the only thing that's different.