### PR TITLE
change release-libs to bash script

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -51,9 +51,16 @@ jobs:
       - quality-checks
     runs-on: ubuntu-latest
     steps:
-      - name: Release any bumped charm library
-        uses: canonical/charming-actions/release-libraries@main
-        with:
-          charm-path: "${{ inputs.charm-path }}"
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}"
+      - name: Release libraries
+        run: |
+          # Install Charmcraft
+          sudo snap install charmcraft --classic --channel latest/stable
+          cd ${{ inputs.charm-path }}
+          # Get the libs folder name
+          libraries_folder=$(yq .name metadata.yaml | tr - _)
+          # For each library belonging to the charm, publish it
+          for lib in $(find lib/charms/$libs_folder -type f | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
+            charmcraft publish-lib $lib
+          done
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"


### PR DESCRIPTION
This is an attempt to fix the recent [errors](https://github.com/canonical/traefik-k8s-operator/actions/runs/6530882725/job/17732342448) with the charming-action that releases the libraries.

Note that this script will try to publish all the libraries that are under the charm name's lib folder; specifically, it will:
1. read the charm name from `metadata.yaml` (e.g., **loki-k8s**)
2. make it snake case (e.g., **loki_k8s**)
3. try to publish all the libraries in `lib/charms/<name>/**` (e.g., **`lib/charms/loki_k8s/**`**)