### PR TITLE
hard reset the OCI Factory fork in CI

### DIFF
--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -51,7 +51,7 @@ jobs:
         if: steps.changed-files.outputs.all_changed_and_modified_files != ''
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
-        run: gh repo sync observability-noctua-bot/oci-factory
+        run: gh repo sync --force observability-noctua-bot/oci-factory
 
       - name: Clone the fork
         id: fork-clone


### PR DESCRIPTION
## Issue

Currently, the `rock-release-oci-factory.yaml` CI workflow can fail when the `canonical/oci-factory` repo rewrites history on main. `gh repo sync` will then fail, as seen [here](https://github.com/canonical/grafana-agent-rock/actions/runs/6862789617/job/18661237568):

```
can't sync because there are diverging changes; use `--force` to overwrite the destination branch
```

## Solution 

To avoid this, we should hard reset the Noctua fork to the `canonical/oci-factory` upstream.