### PR TITLE
fix rock-update to use major-minor go version

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -101,7 +101,9 @@ jobs:
           go_version=$(grep -Po "^go \K(\S+)" $GITHUB_WORKSPACE/application-src/go.mod) \
           # Delete the Go dependency and add the updated one
           yq -i 'del(.parts.${{ inputs.rock-name }}.build-snaps.[] | select(. == "go/*"))' $GITHUB_WORKSPACE/main/$version/rockcraft.yaml
-          go_v="$go_version" yq -i '.parts.${{ inputs.rock-name }}.build-snaps += "go/"+strenv(go_v)+"/stable"' $GITHUB_WORKSPACE/main/$version/rockcraft.yaml
+          # Snap channels are named after major.minor only, so cut the go version to that format
+          go_major_minor=$(echo $go_version | sed -E "s/([0-9]+\.[0-9]+).*/\1/"))
+          go_v="$go_major_minor" yq -i '.parts.${{ inputs.rock-name }}.build-snaps += "go/"+strenv(go_v)+"/stable"' $GITHUB_WORKSPACE/main/$version/rockcraft.yaml
 
       - name: Update other build dependencies
         if: steps.check.outputs.release != '' && inputs.update-script != ''


### PR DESCRIPTION
The `rock-update` workflow gets the Go version from the upstream project's `go.mod` file, where it can be expressed in any form (e.g., `1.20`, `1.20.1`, etc). However, when the ROCK is built, the `go` binary is taken from the Snap, which names its channels after `major.minor` only.

The workflow needs to cut the Go version to the `major.minor` format, so the ROCK can reference the correct snap channel when packing.