### PR TITLE
feat: added one additional ip range to metallb

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -14,10 +14,12 @@ on:
         type: string
         description: "The first IP address in the address pool for the load balancer to use"
         required: false
+        default: "{{ env.IPADDR }}"
       ip-range-end:
         type: string
         description: "The last IP address in the address pool for the load balancer to use"
         required: false
+        default: "{{ env.IPADDR }}"
     secrets:
       CHARMHUB_TOKEN:
         required: false

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -10,6 +10,14 @@ on:
         type: string
         description: "The provider to choose for either machine or k8s tests ('lxd' or 'microk8s')"
         required: true
+      ip-range-start:
+        type: string
+        description: "The first IP address in the address pool for the load balancer to use"
+        required: false
+      ip-range-end:
+        type: string
+        description: "The last IP address in the address pool for the load balancer to use"
+        required: false
     secrets:
       CHARMHUB_TOKEN:
         required: false
@@ -79,6 +87,8 @@ jobs:
     with:
       charm-path: "${{ inputs.charm-path }}"
       provider: "${{ inputs.provider }}"
+      ip-range-start: ${{ inputs.ip-range-start }}
+      ip-range-end: ${{ inputs.ip-range-end }}
   codeql:
     name: CodeQL analysis
     needs:

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -42,7 +42,7 @@ jobs:
           provider: microk8s
           channel: 1.26-strict/stable
           microk8s-group: snap_microk8s
-          microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
+          microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }},10.64.140.43-10.64.140.49"
       - name: Run integration tests
         run: cd ${{ inputs.charm-path }} && tox -vve integration
       - name: Dump debug log

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -14,10 +14,12 @@ on:
         type: string
         description: "The first IP address in the address pool for the load balancer to use"
         required: false
+        default: "{{ env.IPADDR }}"
       ip-range-end:
         type: string
         description: "The last IP address in the address pool for the load balancer to use"
         required: false
+        default: "{{ env.IPADDR }}"
 
 # Default to bash
 defaults:
@@ -42,11 +44,9 @@ jobs:
         with:
           juju-channel: 3.1/edge
           provider: lxd
-      - name: Setup operator environment (k8s) with load balancer IP range
+      - name: Setup operator environment (k8s)
         if: |
-          inputs.provider == 'microk8s' &&
-          inputs.ip-range-start != '' &&
-          inputs.ip-range-end != ''
+          inputs.provider == 'microk8s'
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.1/edge
@@ -54,17 +54,6 @@ jobs:
           channel: 1.26-strict/stable
           microk8s-group: snap_microk8s
           microk8s-addons: "hostpath-storage dns metallb:${{ inputs.ip-range-start }}-${{ inputs.ip-range-end }}"
-      - name: Setup operator environment (k8s)
-        if: |
-          inputs.provider == 'microk8s' &&
-          (inputs.ip-range-start == '' || inputs.ip-range-end == '')
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          juju-channel: 3.1/edge
-          provider: microk8s
-          channel: 1.26-strict/stable
-          microk8s-group: snap_microk8s
-          microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
       - name: Run integration tests
         run: cd ${{ inputs.charm-path }} && tox -vve integration
       - name: Dump debug log

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -10,6 +10,14 @@ on:
         type: string
         description: "The provider to choose for either machine or k8s tests ('lxd' or 'microk8s')"
         required: true
+      ip-range-start:
+        type: string
+        description: "The first IP address in the address pool for the load balancer to use"
+        required: false
+      ip-range-end:
+        type: string
+        description: "The last IP address in the address pool for the load balancer to use"
+        required: false
 
 # Default to bash
 defaults:
@@ -34,15 +42,29 @@ jobs:
         with:
           juju-channel: 3.1/edge
           provider: lxd
-      - name: Setup operator environment (k8s)
-        if: inputs.provider == 'microk8s'
+      - name: Setup operator environment (k8s) with load balancer IP range
+        if: |
+          inputs.provider == 'microk8s' &&
+          inputs.ip-range-start != '' &&
+          inputs.ip-range-end != ''
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.1/edge
           provider: microk8s
           channel: 1.26-strict/stable
           microk8s-group: snap_microk8s
-          microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }},10.64.140.43-10.64.140.49"
+          microk8s-addons: "hostpath-storage dns metallb:${{ inputs.ip-range-start }}-${{ inputs.ip-range-end }}"
+      - name: Setup operator environment (k8s)
+        if: |
+          inputs.provider == 'microk8s' &&
+          (inputs.ip-range-start == '' || inputs.ip-range-end == '')
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: 3.1/edge
+          provider: microk8s
+          channel: 1.26-strict/stable
+          microk8s-group: snap_microk8s
+          microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
       - name: Run integration tests
         run: cd ${{ inputs.charm-path }} && tox -vve integration
       - name: Dump debug log

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -13,6 +13,14 @@ on:
         default: 'microk8s'
         required: false
         type: string
+      ip-range-start:
+        type: string
+        description: "The first IP address in the address pool for the load balancer to use"
+        required: false
+      ip-range-end:
+        type: string
+        description: "The last IP address in the address pool for the load balancer to use"
+        required: false
     secrets:
        CHARMHUB_TOKEN:
          required: false
@@ -60,3 +68,5 @@ jobs:
     with:
       charm-path: ${{ inputs.charm-path }}
       provider: ${{ inputs.provider }}
+      ip-range-start: ${{ inputs.ip-range-start }}
+      ip-range-end: ${{ inputs.ip-range-end }}

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -17,10 +17,12 @@ on:
         type: string
         description: "The first IP address in the address pool for the load balancer to use"
         required: false
+        default: "{{ env.IPADDR }}"
       ip-range-end:
         type: string
         description: "The last IP address in the address pool for the load balancer to use"
         required: false
+        default: "{{ env.IPADDR }}"
     secrets:
        CHARMHUB_TOKEN:
          required: false

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -18,6 +18,14 @@ on:
         default: 'microk8s'
         required: false
         type: string
+      ip-range-start:
+        type: string
+        description: "The first IP address in the address pool for the load balancer to use"
+        required: false
+      ip-range-end:
+        type: string
+        description: "The last IP address in the address pool for the load balancer to use"
+        required: false
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -36,6 +44,8 @@ jobs:
     with:
       charm-path: "${{ inputs.charm-path }}"
       provider: "${{ inputs.provider }}"
+      ip-range-start: ${{ inputs.ip-range-start }}
+      ip-range-end: ${{ inputs.ip-range-end }}
   release-charm:
     name: Release Charm and Libraries
     needs:

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -22,10 +22,12 @@ on:
         type: string
         description: "The first IP address in the address pool for the load balancer to use"
         required: false
+        default: "{{ env.IPADDR }}"
       ip-range-end:
         type: string
         description: "The last IP address in the address pool for the load balancer to use"
         required: false
+        default: "{{ env.IPADDR }}"
     secrets:
       CHARMHUB_TOKEN:
         required: true


### PR DESCRIPTION
The integration test for [pr 224](https://github.com/canonical/grafana-k8s-operator/pull/278) requires a load balancer with a larger IP range. This pr initializes metallb with an additional range of addresses.