### PR TITLE
Use juju 3.4 in charm integration tests

### DIFF
--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -32,13 +32,13 @@ jobs:
         if: inputs.provider == 'lxd'
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.1/edge
+          juju-channel: 3.4/edge
           provider: lxd
       - name: Setup operator environment (k8s)
         if: inputs.provider == 'microk8s'
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.1/edge
+          juju-channel: 3.2/edge
           provider: microk8s
           channel: 1.26-strict/stable
           microk8s-group: snap_microk8s

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -38,7 +38,7 @@ jobs:
         if: inputs.provider == 'microk8s'
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.2/edge
+          juju-channel: 3.4/edge
           provider: microk8s
           channel: 1.26-strict/stable
           microk8s-group: snap_microk8s

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -32,13 +32,13 @@ jobs:
         if: inputs.provider == 'lxd'
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.4/edge
+          juju-channel: 3.3/edge
           provider: lxd
       - name: Setup operator environment (k8s)
         if: inputs.provider == 'microk8s'
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.4/edge
+          juju-channel: 3.3/edge
           provider: microk8s
           channel: 1.26-strict/stable
           microk8s-group: snap_microk8s

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -32,13 +32,13 @@ jobs:
         if: inputs.provider == 'lxd'
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.3/edge
+          juju-channel: 3.4/edge
           provider: lxd
       - name: Setup operator environment (k8s)
         if: inputs.provider == 'microk8s'
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.3/edge
+          juju-channel: 3.4/edge
           provider: microk8s
           channel: 1.26-strict/stable
           microk8s-group: snap_microk8s


### PR DESCRIPTION
The juju 3.1 snap channel was suddenly removed, and that broke all of our CI pipeline for charms.

Possible choices are `3.2`, `3.3`, `3.4`, `4.0`; I'm picking the same major and latest minor, but chime in if you think a different one is better.