### PR TITLE
Dump nodes info for failing integration tests

### DIFF
--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -66,6 +66,11 @@ jobs:
                       --tail=100; \
                done
           exit 0
+      - name: Dump node information
+        if: failure()
+        run: |
+          kubectl get nodes -v=10
+          exit 0
       - name: Dump deployments
         if: failure()
         run: |


### PR DESCRIPTION
As our integration test pipelines fail for repos using charm-tests-integration, we may want to go through nodes info to troubleshoot further.