### PR TITLE
Add IP Range

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -10,6 +10,13 @@ on:
         type: string
         description: "The provider to choose for either machine or k8s tests ('lxd' or 'microk8s')"
         required: true
+      ip-range:
+        type: string
+        description: |
+          The IP range in the address pool for the load balancer to use.
+          It can be either a subnet(IP/mask) or a range (<IP1>-<IP2>)
+        required: false
+        default: ""
     secrets:
       CHARMHUB_TOKEN:
         required: false
@@ -79,6 +86,7 @@ jobs:
     with:
       charm-path: "${{ inputs.charm-path }}"
       provider: "${{ inputs.provider }}"
+      ip-range: ${{ inputs.ip-range }}
   codeql:
     name: CodeQL analysis
     needs:

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -16,7 +16,7 @@ on:
           The IP range in the address pool for the load balancer to use.
           It can be either a subnet(IP/mask) or a range (<IP1>-<IP2>)
         required: false
-        default: ""
+        default: null
     secrets:
       CHARMHUB_TOKEN:
         required: false

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -41,13 +41,13 @@ jobs:
         if: inputs.provider == 'lxd'
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.4/edge
+          juju-channel: 3.3/stable
           provider: lxd
       - name: Setup operator environment (k8s)
         if: inputs.provider == 'microk8s'
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.4/edge
+          juju-channel: 3.3/stable
           provider: microk8s
           channel: 1.26-strict/stable
           microk8s-group: snap_microk8s

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -16,7 +16,7 @@ on:
           The IP range in the address pool for the load balancer to use.
           It can be either a subnet(IP/mask) or a range (<IP1>-<IP2>)
         required: false
-        default: ""
+        default: null
 
 # Default to bash
 defaults:

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -10,6 +10,13 @@ on:
         type: string
         description: "The provider to choose for either machine or k8s tests ('lxd' or 'microk8s')"
         required: true
+      ip-range:
+        type: string
+        description: |
+          The IP range in the address pool for the load balancer to use.
+          It can be either a subnet(IP/mask) or a range (<IP1>-<IP2>)
+        required: false
+        default: ""
 
 # Default to bash
 defaults:
@@ -25,9 +32,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - name: Get prefsrc
+      - name: Get IP range
+        id: ip_range
+        if: ${{ inputs.ip-range == '' }}
         run: |
-          echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV
+          echo "ip_range=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')/32" >> $GITHUB_OUTPUT
       - name: Setup operator enviroment (machine)
         if: inputs.provider == 'lxd'
         uses: charmed-kubernetes/actions-operator@main
@@ -42,7 +51,7 @@ jobs:
           provider: microk8s
           channel: 1.26-strict/stable
           microk8s-group: snap_microk8s
-          microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
+          microk8s-addons: "hostpath-storage dns metallb:${{ inputs.ip-range || steps.ip_range.outputs.ip_range }}"
       - name: Run integration tests
         run: cd ${{ inputs.charm-path }} && tox -vve integration
       - name: Dump debug log

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -13,6 +13,13 @@ on:
         default: 'microk8s'
         required: false
         type: string
+      ip-range:
+        type: string
+        description: |
+          The IP range in the address pool for the load balancer to use.
+          It can be either a subnet(IP/mask) or a range (<IP1>-<IP2>)
+        required: false
+        default: ""
     secrets:
        CHARMHUB_TOKEN:
          required: false
@@ -60,3 +67,4 @@ jobs:
     with:
       charm-path: ${{ inputs.charm-path }}
       provider: ${{ inputs.provider }}
+      ip-range: ${{ inputs.ip-range }}

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -19,7 +19,7 @@ on:
           The IP range in the address pool for the load balancer to use.
           It can be either a subnet(IP/mask) or a range (<IP1>-<IP2>)
         required: false
-        default: ""
+        default: null
     secrets:
        CHARMHUB_TOKEN:
          required: false

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -18,6 +18,13 @@ on:
         default: 'microk8s'
         required: false
         type: string
+      ip-range:
+        type: string
+        description: |
+          The IP range in the address pool for the load balancer to use.
+          It can be either a subnet(IP/mask) or a range (<IP1>-<IP2>)
+        required: false
+        default: ""
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -36,6 +43,7 @@ jobs:
     with:
       charm-path: "${{ inputs.charm-path }}"
       provider: "${{ inputs.provider }}"
+      ip-range: "${{ inputs.ip-range }}"
   release-charm:
     name: Release Charm and Libraries
     needs:

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -24,7 +24,7 @@ on:
           The IP range in the address pool for the load balancer to use.
           It can be either a subnet(IP/mask) or a range (<IP1>-<IP2>)
         required: false
-        default: ""
+        default: null
     secrets:
       CHARMHUB_TOKEN:
         required: true


### PR DESCRIPTION
This PR:
1) Adds back the IP range option (needed for https://github.com/canonical/grafana-k8s-operator/pull/278)
2) Pins the juju version to 3.3/stable (edge requires you to build the controller images on your own.......)

I failed to test it from my fork, I would appreciate some help with this.