### PR TITLE
Update repo for `Inclusive-naming`

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -35,7 +35,7 @@ jobs:
   call-inclusive-naming-check:
     # Issues with this workflow can be addressed by adding a .wokeignore in the repository root
     name: Inclusive naming
-    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/Inclusive-naming/.github/workflows/woke.yaml@main
     with:
       fail-on-error: "true"
   lib-check:


### PR DESCRIPTION
CI was [failing](https://github.com/canonical/cos-lib/actions/runs/7804486845/job/21286543131?pr=14):
```
Error: Unable to resolve action. Repository not found: canonical-web-and-design/Inclusive-naming
```

Apparently changed from `canonical-web-and-design/Inclusive-naming` to [`canonical/Inclusive-naming`](https://github.com/canonical/Inclusive-naming).