### PR TITLE
Allow building charms for arm

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -12,6 +12,13 @@ on:
         default: ''
         required: false
         type: string
+      build-for-arm:
+        type: boolean
+        default: false
+        required: false
+        description: >
+          Whether or not to build the charm for arm64. Defaults to false.
+        
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -56,15 +63,55 @@ jobs:
       - name: Step output
         run: |
           echo "${{ fromjson(steps.builder.outputs.charms) }} "
+  build-arm:
+    if: ${{ inputs.build-for-arm }}
+    runs-on: Ubuntu_ARM64_4C_16G_01
+    outputs:
+      charms: ${{ steps.builder.outputs.charms }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Download Artifact
+        uses: actions/download-artifact@v3
+        id: download_artifact
+        with:
+          name: "${{ inputs.artifact }}"
+        if: ${{ inputs.artifact != '' }}
+      - name: Unpack Artifact
+        run: sudo apt-get update && sudo apt-get install tar && tar xf artifact.tar.gz
+        if: ${{ inputs.artifact != '' }}
+      - name: Setup dependencies
+        id: setup-deps
+        run: |
+          sudo snap install jq
+          sudo snap install lxd
+          sudo lxd init --auto
+          sudo snap install charmcraft --classic
+      - name: Build charm(s)
+        id: builder
+        run: |    
+          charmcraft pack --project-dir ${{ inputs.charm-path }}
+          export CHARMS=$(ls ${{ inputs.charm-path }}/*.charm | jq -R -s -c 'split("\n")[:-1]')
+          echo "charms=$CHARMS" >> "$GITHUB_OUTPUT"
+      - name: Store charms
+        uses: actions/upload-artifact@v3
+        with:
+          name: charms-arm
+          path: ${{ inputs.charm-path }}/*.charm
   charm-output:
     name: Charm List
     runs-on: ubuntu-22.04
     needs:
       - build
+      - build-arm
     steps:
       - name: Job output
         run: |
-          echo job output: ${{ fromjson(needs.build.outputs.charms) }}
+          echo x86 Charms:\n---\n${{ fromjson(needs.build.outputs.charms) }}\n\n
+          echo ARM64 Charms:\n---\n${{ fromjson(needs.build-arm.outputs.charms) }}
+
   release-to-charmhub:
     name: Release to CharmHub
     runs-on: ubuntu-22.04
@@ -73,6 +120,36 @@ jobs:
     strategy:
       matrix:
         path: ${{ fromjson(needs.build.outputs.charms) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@2.1.1
+        id: channel
+      - name: Fetch charm artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: charms
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@2.4.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"
+          built-charm-path: "${{ matrix.path }}"
+          # We set destructive mode to false, otherwise runner's OS would have to match
+          # charm's 'build-on' OS.
+          destructive-mode: false
+  release-arm-to-charmhub:
+    name: Release arm64 to CharmHub
+    runs-on: ubuntu-22.04
+    needs:
+      - build-arm
+    strategy:
+      matrix: 
+        path: ${{ fromjson(needs.build-arm.outputs.charms) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -64,6 +64,7 @@ jobs:
         run: |
           echo "${{ fromjson(steps.builder.outputs.charms) }} "
   build-arm:
+    name: Build the charms for ARM
     if: ${{ inputs.build-for-arm }}
     runs-on: Ubuntu_ARM64_4C_16G_01
     outputs:

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -54,7 +54,7 @@ jobs:
     name: Release Charm and Libraries
     needs:
       - quality-checks
-    uses: canonical/observability/.github/workflows/_charm-release.yaml@main
+    uses: canonical/observability/.github/workflows/_charm-release.yaml@fix/build-for-arm
     secrets: inherit
     with:
       artifact: "${{ inputs.artifact }}"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -25,6 +25,12 @@ on:
           It can be either a subnet(IP/mask) or a range (<IP1>-<IP2>)
         required: false
         default: null
+      build-for-arm:
+        type: boolean
+        default: false
+        required: false
+        description: |
+          Whether or not to also build the charm for arm64. Defaults to false. 
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -53,6 +59,7 @@ jobs:
     with:
       artifact: "${{ inputs.artifact }}"
       charm-path: "${{ inputs.charm-path }}"
+      build-for-arm: ${{ inputs.build-for-arm }}
   release-libs:
     name: Release any bumped charm library
     needs:

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -54,7 +54,7 @@ jobs:
     name: Release Charm and Libraries
     needs:
       - quality-checks
-    uses: canonical/observability/.github/workflows/_charm-release.yaml@fix/build-for-arm
+    uses: canonical/observability/.github/workflows/_charm-release.yaml@main
     secrets: inherit
     with:
       artifact: "${{ inputs.artifact }}"


### PR DESCRIPTION
This PR adds support for building charms for arm64 by supplying the `build-for-arm` boolean input parameter.