### PR TITLE
Allow charm release when charm has no libraries or metadata.yaml

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Check charm libraries # Make sure our charm libraries are updated
-        uses: canonical/charming-actions/check-libraries@2.4.0
+        uses: canonical/charming-actions/check-libraries@2.5.0-rc
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -134,7 +134,7 @@ jobs:
         with:
           name: charms
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.4.0
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -164,7 +164,7 @@ jobs:
         with:
           name: charms-arm
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.4.0
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/charm-promote.yaml
+++ b/.github/workflows/charm-promote.yaml
@@ -37,7 +37,7 @@ jobs:
             echo "promote-to=stable" >> ${GITHUB_ENV}
           fi
       - name: Promote Charm
-        uses: canonical/charming-actions/release-charm@2.4.0
+        uses: canonical/charming-actions/release-charm@2.5.0-rc
         with:
           charm-path: ${{ inputs.charm-path }}
           credentials: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -77,15 +77,14 @@ jobs:
           # Install Charmcraft
           sudo snap install charmcraft --classic --channel latest/stable
           cd $GITHUB_WORKSPACE/charm/${{ inputs.charm-path }}
-          # Get the libs folder name
-          if [ -f metadata.yaml ]; then
-            libraries_folder=$(yq .name metadata.yaml | tr - _)
-          else
-            libraries_folder=$(yq .name charmcraft.yaml | tr - _)
-          fi
+          # Get the charm name
+          charm_name=$((yq .name metadata.yaml 2>/dev/null || yq .name charmcraft.yaml) | tr - _)
+          if [[ "$charm_name = "" ]]; then echo "Error: can't extract the charm name." && exit 1; fi
           # For each library belonging to the charm, publish it
-          for lib in $(find lib/charms/$libraries_folder -type f | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
-            charmcraft publish-lib $lib
-          done
+          if [ -d lib/charms/$charm_name ]; then
+            for lib in $(find lib/charms/$charm_name -type f | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
+              charmcraft publish-lib $lib
+            done
+          fi
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -54,7 +54,7 @@ jobs:
     name: Release Charm and Libraries
     needs:
       - quality-checks
-    uses: skatsaounis/observability/.github/workflows/_charm-release.yaml@fix-tests
+    uses: canonical/observability/.github/workflows/_charm-release.yaml@main
     secrets: inherit
     with:
       artifact: "${{ inputs.artifact }}"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -54,7 +54,7 @@ jobs:
     name: Release Charm and Libraries
     needs:
       - quality-checks
-    uses: canonical/observability/.github/workflows/_charm-release.yaml@main
+    uses: skatsaounis/observability/.github/workflows/_charm-release.yaml@fix-tests
     secrets: inherit
     with:
       artifact: "${{ inputs.artifact }}"
@@ -78,10 +78,16 @@ jobs:
           sudo snap install charmcraft --classic --channel latest/stable
           cd $GITHUB_WORKSPACE/charm/${{ inputs.charm-path }}
           # Get the libs folder name
-          libraries_folder=$(yq .name metadata.yaml | tr - _)
-          # For each library belonging to the charm, publish it
-          for lib in $(find lib/charms/$libraries_folder -type f | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
-            charmcraft publish-lib $lib
-          done
+          if [ -e metadata.yaml ]; then
+            libraries_folder=$(yq .name metadata.yaml | tr - _)
+          else
+            libraries_folder=$(yq .name charmcraft.yaml | tr - _)
+          fi
+          if [ -e lib/charms/$libraries_folder ]; then
+            # For each library belonging to the charm, publish it
+            for lib in $(find lib/charms/$libraries_folder -type f | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
+              charmcraft publish-lib $lib
+            done
+          fi
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -83,11 +83,9 @@ jobs:
           else
             libraries_folder=$(yq .name charmcraft.yaml | tr - _)
           fi
-          if [ -e lib/charms/$libraries_folder ]; then
-            # For each library belonging to the charm, publish it
-            for lib in $(find lib/charms/$libraries_folder -type f | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
-              charmcraft publish-lib $lib
-            done
-          fi
+          # For each library belonging to the charm, publish it
+          for lib in $(find lib/charms/$libraries_folder -type f | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
+            charmcraft publish-lib $lib
+          done
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -78,7 +78,7 @@ jobs:
           sudo snap install charmcraft --classic --channel latest/stable
           cd $GITHUB_WORKSPACE/charm/${{ inputs.charm-path }}
           # Get the libs folder name
-          if [ -e metadata.yaml ]; then
+          if [ -f metadata.yaml ]; then
             libraries_folder=$(yq .name metadata.yaml | tr - _)
           else
             libraries_folder=$(yq .name charmcraft.yaml | tr - _)


### PR DESCRIPTION
This PR:

- bumps `canonical/charming-actions/upload-charm` to `2.5.0-rc` to include https://github.com/canonical/charming-actions/pull/132
- checks for the existence of `metadata.yaml` and when not found, tries to get the charm name from `charmcraft.yaml`
- checks for the existence of charm owned libraries before trying to release them