### PR TITLE
fix: proper support release of charms inside a path

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           sudo snap install jq
           sudo snap install charmcraft --classic
-          charmcraft pack --project-dir ${{ inputs.charm-path }}
+          (cd ${{ inputs.charm-path }}; charmcraft pack)
           export CHARMS=$(ls ${{ inputs.charm-path }}/*.charm | jq -R -s -c 'split("\n")[:-1]')
           echo "charms=$CHARMS" >> "$GITHUB_OUTPUT"
       - name: Store charms
@@ -93,7 +93,7 @@ jobs:
       - name: Build charm(s)
         id: builder
         run: |    
-          charmcraft pack --project-dir ${{ inputs.charm-path }}
+          (cd ${{ inputs.charm-path }}; charmcraft pack)
           export CHARMS=$(ls ${{ inputs.charm-path }}/*.charm | jq -R -s -c 'split("\n")[:-1]')
           echo "charms=$CHARMS" >> "$GITHUB_OUTPUT"
       - name: Store charms


### PR DESCRIPTION
This PR fixes the failed release of charms that are placed inside a path.

Charmcraft can allow someone to pack a charm that is placed in a different path but it cannot set the output path. Additionally, it creates the charm in the directory from where `charmcraft` is invoked.