### PR TITLE
feat: allow overriding concurrency group

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -31,6 +31,11 @@ on:
         required: false
         description: |
           Whether or not to also build the charm for arm64. Defaults to false.
+      concurrency-group:
+        required: false
+        default: 'release'
+        type: string
+        description: "Concurrency group to set"
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -38,7 +43,7 @@ on:
         required: true
 
 concurrency:
-  group: release
+  group: ${{ inputs.concurrency-group }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This PR enables the scenario of running observability charm release on GitHub repos that contain more than one charm

Example:

```yaml
name: Release Charms to Edge and Publish Libraries
on:
  push:
    branches:
      - main

jobs:
  charm-one:
    uses: canonical/observability/.github/workflows/charm-release.yaml@main
    secrets: inherit
    with:
      charm-path: charm-one
      concurrency-group: charm-one
  charm-two:
    uses: canonical/observability/.github/workflows/charm-release.yaml@main
    secrets: inherit
    with:
      charm-path: charm-two
      concurrency-group: charm-two
```