### PR TITLE
fix: publish charm on different path

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -140,6 +140,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
           built-charm-path: "${{ matrix.path }}"
+          charm-path: "${{ inputs.charm-path }}"
           # We set destructive mode to false, otherwise runner's OS would have to match
           # charm's 'build-on' OS.
           destructive-mode: false
@@ -170,6 +171,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
           built-charm-path: "${{ matrix.path }}"
+          charm-path: "${{ inputs.charm-path }}"
           # We set destructive mode to false, otherwise runner's OS would have to match
           # charm's 'build-on' OS.
           destructive-mode: false


### PR DESCRIPTION
Fix the upload-charm action on charms that are placed in a different path than the `.`

Based on https://github.com/canonical/charming-actions/tree/2.5.0-rc/upload-charm#inputs:

| Key  |  Description |  Required |
| -- | -- | -- |
| charm-path |	Path to the charm we want to publish. Defaults to the current working directory. | |
