### PR TITLE
fix: fetch charm artifacts to proper path

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -133,6 +133,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: charms
+          path: "${{ github.workspace }}/${{ inputs.charm-path }}"
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
@@ -163,6 +164,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: charms-arm
+          path: "${{ github.workspace }}/${{ inputs.charm-path }}"
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:


### PR DESCRIPTION
To release charms inside a path, the artifact should be downloaded at the same path were it was created in the build step.

To allow successful release of charms placed in `.` directory, the default value is used: `/home/runner/work/maas-charms/maas-charms/.`. That's true because the default `inputs.charm-path` is `.` and also the default value for path is `GITHUB_WORKSPACE`.

Links:

- https://github.com/actions/download-artifact/blob/main/README.md?plain=1#L56-L58
  ```yaml
  # Destination path. Supports basic tilde expansion.
  # Optional. Default is $GITHUB_WORKSPACE
  path:
  ```
- https://raw.githubusercontent.com/actions/download-artifact/main/dist/index.js
  ```ts
    if (!inputs.path) {
        inputs.path = process.env['GITHUB_WORKSPACE'] || process.cwd();
    }
  ```

**Current situation**

```bash
...
Charm packed ok
##[debug]Set output charms = ["maas-region/maas-region_ubuntu-22.04-amd64.charm"]
##[debug]Finishing: Build charm(s)
...
With the provided path, there will be 1 file uploaded
##[debug]Root artifact directory is /home/runner/work/maas-charms/maas-charms/maas-region
Starting artifact upload
...
Directory structure has been setup for the artifact
Total number of files that will be downloaded: 1
##[debug]File: 1/1. /home/runner/work/maas-charms/maas-charms/maas-region_ubuntu-22.04-amd64.charm took 940.705 milliseconds to finish downloading
Artifact charms was downloaded to /home/runner/work/maas-charms/maas-charms
Artifact download has finished successfully
...
/usr/bin/sudo snap install charmcraft --classic --channel latest/stable
charmcraft 2.5.5 from Canonical** installed
/snap/bin/charmcraft upload --format json --release latest/edge maas-region/maas-region_ubuntu-22.04-amd64.charm
Cannot access 'maas-region/maas-region_ubuntu-22.04-amd64.charm'.
...
```

**Expected path to make the release work**

```
Artifact charms was downloaded to /home/runner/work/maas-charms/maas-charms/maas-region
```