### PR TITLE
fix: update the matrix paths to be relative from charm-path

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -53,7 +53,7 @@ jobs:
           sudo snap install jq
           sudo snap install charmcraft --classic
           (cd ${{ inputs.charm-path }}; charmcraft pack)
-          export CHARMS=$(ls ${{ inputs.charm-path }}/*.charm | jq -R -s -c 'split("\n")[:-1]')
+          export CHARMS=$(basename -a ${{ inputs.charm-path }}/*.charm | jq -R -s -c 'split("\n")[:-1]')
           echo "charms=$CHARMS" >> "$GITHUB_OUTPUT"
       - name: Store charms
         uses: actions/upload-artifact@v3
@@ -94,7 +94,7 @@ jobs:
         id: builder
         run: |    
           (cd ${{ inputs.charm-path }}; charmcraft pack)
-          export CHARMS=$(ls ${{ inputs.charm-path }}/*.charm | jq -R -s -c 'split("\n")[:-1]')
+          export CHARMS=$(basename -a ${{ inputs.charm-path }}/*.charm | jq -R -s -c 'split("\n")[:-1]')
           echo "charms=$CHARMS" >> "$GITHUB_OUTPUT"
       - name: Store charms
         uses: actions/upload-artifact@v3
@@ -140,7 +140,7 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
-          built-charm-path: "../${{ matrix.path }}"
+          built-charm-path: "${{ matrix.path }}"
           charm-path: "${{ inputs.charm-path }}"
           # We set destructive mode to false, otherwise runner's OS would have to match
           # charm's 'build-on' OS.
@@ -172,7 +172,7 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
-          built-charm-path: "../${{ matrix.path }}"
+          built-charm-path: "${{ matrix.path }}"
           charm-path: "${{ inputs.charm-path }}"
           # We set destructive mode to false, otherwise runner's OS would have to match
           # charm's 'build-on' OS.

--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -140,7 +140,7 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
-          built-charm-path: "${{ matrix.path }}"
+          built-charm-path: "../${{ matrix.path }}"
           charm-path: "${{ inputs.charm-path }}"
           # We set destructive mode to false, otherwise runner's OS would have to match
           # charm's 'build-on' OS.
@@ -172,7 +172,7 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
-          built-charm-path: "${{ matrix.path }}"
+          built-charm-path: "../${{ matrix.path }}"
           charm-path: "${{ inputs.charm-path }}"
           # We set destructive mode to false, otherwise runner's OS would have to match
           # charm's 'build-on' OS.


### PR DESCRIPTION
~This PR is adding a `../` prefix to `built-charm-path` so that charms on different path than the default can be uploaded.~

~With the merging of #162 a new bug was introduced instead of fixing the issue. The charm is placed at the correct place but while the `charm-path` is set correctly and `charmcraft.yaml` is properly consumed, the `built-charm-path` already includes the `charm-path`. As a result the following is tried:~

```bash
# charm-path=subdir
# built-charm-path=subdir/charm.charm

cd $charm-path
charmcraft upload --format json --release latest/edge $built-charm-path

Cannot access 'subdir/charm.charm'.
```

~This is the relevant JS code that is doing the equivalent to the above pseudo-code: https://github.com/canonical/charming-actions/blob/2.5.0-rc/dist/upload-charm/index.js#L42320-L42348~