### PR TITLE
feat: add release tag prefix optional input

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -7,6 +7,11 @@ on:
         type: string
         required: false
         default: .
+      release-tag-prefix:
+        description: "Tag prefix to use for the tag of the GitHub release."
+        default: ''
+        required: false
+        type: string
       artifact:
         description: "Name of artifact to download before building. Must contain the file artifact.tar.gz."
         default: ''
@@ -142,6 +147,7 @@ jobs:
           channel: "${{ steps.channel.outputs.name }}"
           built-charm-path: "${{ matrix.path }}"
           charm-path: "${{ inputs.charm-path }}"
+          tag-prefix: "${{ inputs.release-tag-prefix }}"
           # We set destructive mode to false, otherwise runner's OS would have to match
           # charm's 'build-on' OS.
           destructive-mode: false
@@ -174,6 +180,7 @@ jobs:
           channel: "${{ steps.channel.outputs.name }}"
           built-charm-path: "${{ matrix.path }}"
           charm-path: "${{ inputs.charm-path }}"
+          tag-prefix: "${{ inputs.release-tag-prefix }}"
           # We set destructive mode to false, otherwise runner's OS would have to match
           # charm's 'build-on' OS.
           destructive-mode: false

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -8,6 +8,11 @@ on:
         default: '.'
         required: false
         type: string
+      release-tag-prefix:
+        description: "Tag prefix to use for the tag of the GitHub release."
+        default: ''
+        required: false
+        type: string
       artifact:
         description: "Name of artifact to download before building. Must contain the file artifact.tar.gz."
         default: ''
@@ -59,6 +64,7 @@ jobs:
     with:
       artifact: "${{ inputs.artifact }}"
       charm-path: "${{ inputs.charm-path }}"
+      release-tag-prefix: "${{ inputs.release-tag-prefix }}"
       build-for-arm: ${{ inputs.build-for-arm }}
   release-libs:
     name: Release any bumped charm library


### PR DESCRIPTION
Provide an optional input to set a release tag prefix for GitHub releases that accompany Charmhub published revisions.

This is needed for repos with multiple charms:

https://github.com/canonical/charming-actions/blob/83a27879303e4de116ffbace69da2bff12c9fd64/release-charm/README.md?plain=1#L64

Without this change, those repos have conflicts when charm A is at revision 1, charm B is at revision 2 and the action is trying to create a tag `rev2` after publishing new charm A. `rev2` is a GitHub tag that already exists from the previous run when charm B released revision 2. After the change there is no problem since charm A revision 2 will produce GitHub tag `charm-a-prefix-rev2` which is different than `charm-b-rev2`.