### PR TITLE
sign commits for update-libs and automerge minor library updates

### DIFF
--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # If CI checks are passing on a PR from "chore/auto-libs", merge it
           if gh pr checks chore/auto-libs; then
-            gh pr merge chore/auto-libs --merge --admin
+            gh pr merge chore/auto-libs --admin
           fi
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -62,7 +62,7 @@ jobs:
           # Check if there are already open issues for major library upgrades
           open_issues_count="$(gh issue list --search 'chore: update libraries to new major versions' --state open --json id --jq 'length')"
           echo "open_issues_count = $open_issues_count , issue_body = $issue_body"
-          if [[ "$open_issues_count" == "0" ]] && [[ "$issue_body" != "" ]]; then
+          if [[ "$open_issues_count" == "0" && "$issue_body" != "" ]]; then
             # gh issue create \
             #   --title "chore: update libraries to new major versions" \
             #   --body "This issue was created automatically because a new major version was detected for a charm library.\n\nYou should update the following libraries:\n${issue_body}"            

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -96,5 +96,5 @@ jobs:
 
             The PR will be auto-merged if the CI is green, unless it includes a major library
             version bump; in that case, manual changes are most likely required.
-          branch: "${{ steps.fetch-libraries.outputs.pr_branch }}"
+          branch: chore/auto-libs
           delete-branch: true

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -53,12 +53,12 @@ jobs:
             lib_major=$(cut -d. -f3 <<< "$lib")
             lib_owner=$(cut -d. -f2 <<< "$lib" | tr _ -)
             # Get the latest major version of the library from Charmhub
-            latest_major=$(charmcraft list-lib $lib_owner --format=json | jq -r --arg LIBNAME "$lib_name" '.[] | select(.library_name == $LIBNAME) | .api')
+            latest_major="v$(charmcraft list-lib $lib_owner --format=json | jq -r --arg LIBNAME $lib_name '.[] | select(.library_name == $LIBNAME) | .api')"
             echo "[debug] + lib_major = $lib_major, latest_major = $latest_major"
-            echo "[debug] $(echo $lib_major\nv$latest_major | sort -V | tail -n1)"
+            echo [debug] $(echo "$lib_major\n$latest_major" | sort -V | tail -n1)
             # If there is a new major version of the library, open a new issue
-            if [[ $(echo "$lib_major\nv$latest_major" | sort -V | tail -n1 ) != "$lib_major" ]]; then
-              issue_body="${issue_body}- update $lib to v$latest_major\n"
+            if [[ $(echo "$lib_major\n$latest_major" | sort -V | tail -n1 ) != "$lib_major" ]]; then
+              issue_body="${issue_body}- update $lib to $latest_major\n"
             fi
           done
           # Check if there are already open issues for major library upgrades

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -43,6 +43,8 @@ jobs:
           # Get the charm name
           charm_name=$((yq .name metadata.yaml 2>/dev/null || yq .name charmcraft.yaml) | tr - _)
           if [[ $charm_name = "" ]]; then echo "Error: can't extract the charm name." && exit 1; fi
+          # Initalize the issue body content to empty string, and fill it up in the for loop
+          issue_body=""
           # For each library not belonging to the charm, check for a major version update
           #   "lib" would be of the form `charms.prometheus_k8s.v0.prometheus_scrape`
           for lib in $(find lib/charms/ -type f | grep '.py$' | grep -v "$charm_name" | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
@@ -53,12 +55,20 @@ jobs:
             # Get the latest major version of the library from Charmhub
             latest_major=$(charmcraft list-lib $lib_owner --format=json | jq -r --arg LIBNAME "$lib_name" '.[] | select(.library_name == $LIBNAME) | .api')
             # If there is a new major version of the library, open a new issue
-            if [[ $(echo "$lib_major\n$latest_major$" | sort -V | tail -n1 ) != "$lib_major" ]]; then
-              gh issue create \
-                --title "chore: update $lib to $latest_major" \
-                --body "This issue was created automatically because a new major version was detected for a charm library." 
+            if [[ $(echo "$lib_major\nv$latest_major$" | sort -V | tail -n1 ) != "$lib_major" ]]; then
+              issue_body="${issue_body}- update $lib to v$latest_major\n"
             fi
           done
+          # Check if there are already open issues for major library upgrades
+          open_issues_count="$(gh issue list --search 'chore: update libraries to new major versions' --state open --json id --jq 'length')"
+          echo "open_issues_count = $open_issues_count , issue_body = $issue_body"
+          if [[ "$open_issues_count" == "0" ]] && [[ "$issue_body" != "" ]]; then
+            # gh issue create \
+            #   --title "chore: update libraries to new major versions" \
+            #   --body "This issue was created automatically because a new major version was detected for a charm library.\n\nYou should update the following libraries:\n${issue_body}"            
+            echo "--- dry run ---"
+            echo "New GitHub Issue created!"
+            echo " body - This issue was created automatically because a new major version was detected for a charm library.\n\nYou should update the following libraries:\n${issue_body}"
           cd "$GITHUB_WORKSPACE"
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # If CI checks are passing on a PR from "chore/auto-libs", merge it
           if gh pr checks chore/auto-libs; then
-            gh pr merge chore/auto-libs --merge
+            gh pr merge chore/auto-libs --merge --admin
           fi
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -99,8 +99,8 @@ jobs:
         with:
           token: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
           commit-message: "chore: update charm libraries"
-          committer: "Github Actions <github-actions@github.com>"
-          author: "Github Actions <github-actions@github.com>"
+          committer: "Noctua <webops+observability-noctua-bot@canonical.com>"
+          author: "Noctua <webops+observability-noctua-bot@canonical.com>"
           title: "chore: update charm libraries"
           body: |
             Automated action to fetch latest version of charm libraries. The branch of this PR 

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # If CI checks are passing on a PR from "chore/auto-libs", merge it
           if gh pr checks chore/auto-libs; then
-            gh pr merge chore/auto-libs --admin
+            gh pr merge chore/auto-libs --admin --squash
           fi
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -36,6 +36,10 @@ jobs:
               echo "CI checks are passing, merging the chore/auto-libs PR"
               gh pr merge chore/auto-libs --admin --squash
             fi
+          elif [[ "$is_pr_open" != "0" ]]; then
+            # The number of open PRs should always be either 0 or 1
+            echo "There's two PRs from the same branch; this should never happen!"
+            exit 1
           fi
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -29,10 +29,13 @@ jobs:
 
       - name: Merge update-libs PRs with green CI
         run: |
-          # If CI checks are passing on a PR from "chore/auto-libs", merge it
-          if gh pr checks chore/auto-libs; then
-            echo "CI checks are passing, merging the chore/auto-libs PR"
-            gh pr merge chore/auto-libs --admin --squash
+          # If a PR from "chore/auto-libs" is open and CI checks are passing, merge it
+          is_pr_open="$(gh pr list --head chore/auto-libs --state open --json id --jq 'length')"
+          if [[ "$is_pr_open" == "1" ]]; then
+            if gh pr checks chore/auto-libs; then
+              echo "CI checks are passing, merging the chore/auto-libs PR"
+              gh pr merge chore/auto-libs --admin --squash
+            fi
           fi
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -31,6 +31,7 @@ jobs:
         run: |
           # If CI checks are passing on a PR from "chore/auto-libs", merge it
           if gh pr checks chore/auto-libs; then
+            echo "CI checks are passing, merging the chore/auto-libs PR"
             gh pr merge chore/auto-libs --admin --squash
           fi
         env:
@@ -62,6 +63,7 @@ jobs:
           # Check if there are already open issues for major library upgrades
           open_issues_count="$(gh issue list --search 'chore: update libraries to new major versions' --state open --json id --jq 'length')"
           if [[ "$open_issues_count" == "0" && "$issue_body" != "" ]]; then
+            echo "Creating a GitHub issue for the major library version update"
             issue_body="$(printf "%s\n\n%s\n%s" "This issue was created automatically because a new major version was detected for a charm library." "You should update the following libraries:" "${issue_body}")"
             gh issue create \
               --title "chore: update libraries to new major versions" \

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -56,7 +56,7 @@ jobs:
             latest_major="v$(charmcraft list-lib $lib_owner --format=json | jq -r --arg LIBNAME $lib_name '.[] | select(.library_name == $LIBNAME) | .api')"
             # If there is a new major version of the library, open a new issue
             if [[ $(printf "%s\n%s" "$lib_major" "$latest_major" | sort -V | tail -n1 ) != "$lib_major" ]]; then
-              issue_body=$(printf "%s\n%s" "$issue_body" "- update $lib to $latest_major")
+              issue_body=$(printf "%s\n%s" "$issue_body" "- update <b>$lib</b> to <b>$latest_major</b>")
             fi
           done
           # Check if there are already open issues for major library upgrades

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # If CI checks are passing on a PR from "chore/auto-libs", merge it
           if gh pr checks chore/auto-libs; then
-            gh pr merge chore/auto-libs 
+            gh pr merge chore/auto-libs --auto
           fi
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -42,7 +42,6 @@ jobs:
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
           cd ${{ inputs.charm-path }}
-          pr_title="chore: update charm libraries"; pr_branch="chore/auto-libs"
           # Get the charm name
           charm_name=$((yq .name metadata.yaml 2>/dev/null || yq .name charmcraft.yaml) | tr - _)
           if [[ $charm_name = "" ]]; then echo "Error: can't extract the charm name." && exit 1; fi
@@ -55,16 +54,15 @@ jobs:
             lib_owner=$(cut -d. -f2 <<< "$lib" | tr _ -)
             # Get the latest major version of the library from Charmhub
             latest_major=$(charmcraft list-lib $lib_owner --format=json | jq -r --arg LIBNAME "$lib_name" '.[] | select(.library_name == $LIBNAME) | .api')
-            # If there is a new major version of the library, remove the old one and fetch the new one
+            # If there is a new major version of the library, open a new issue
             if [[ $(echo "$lib_major\n$latest_major$" | sort -V | tail -n1 ) != "$lib_major" ]]; then
-              rm "$lib" && charmcraft fetch-lib charms.$(cut -d. -f2 <<< "$lib").$latest_major.$lib_name
-              pr_title="chore: update charm libraries (major)"; pr_branch="chore/auto-libs-major"
+              gh issue create \
+                --title "chore: update $lib to $latest_major" \
+                --body "This issue was created automatically because a new major version was detected for a charm library." 
             fi
           done
           # Fetch the libraries that have minor version updates
           charmcraft fetch-lib
-          echo "pr_title=$pr_title" >> $GITHUB_OUTPUT
-          echo "pr_branch=$pr_branch" >> $GITHUB_OUTPUT
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"
 
@@ -82,10 +80,10 @@ jobs:
         id: cpr
         with:
           token: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
-          commit-message: "${{ steps.fetch-libraries.outputs.pr_title }}"
+          commit-message: "chore: update charm libraries"
           committer: "Github Actions <github-actions@github.com>"
           author: "Github Actions <github-actions@github.com>"
-          title: "${{ steps.fetch-libraries.outputs.pr_title }}"
+          title: "chore: update charm libraries"
           body: |
             Automated action to fetch latest version of charm libraries. The branch of this PR 
             will be wiped during the next check. Unless you really know what you're doing, you 

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -51,7 +51,7 @@ jobs:
           issue_body=""
           # For each library not belonging to the charm, check for a major version update
           #   "lib" would be of the form `charms.prometheus_k8s.v0.prometheus_scrape`
-          for lib in $(find lib/charms/ -type f | grep '.py$' | grep -v "$charm_name" | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
+          for lib in $(find "lib/charms/$charm_name" -type f -name "*.py" | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
             # Extract the name of the library, the current major version, and the charm that owns it
             lib_name=$(cut -d. -f4 <<< "$lib")
             lib_major=$(cut -d. -f3 <<< "$lib")

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # If CI checks are passing on a PR from "chore/auto-libs", merge it
           if gh pr checks chore/auto-libs; then
-            gh pr merge chore/auto-libs --merge --auto
+            gh pr merge chore/auto-libs --merge
           fi
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -27,11 +27,44 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Merge update-libs PRs with green CI
+        run: |
+          # If CI is passing on PRs from "chore/auto-libs", merge it
+          if gh pr checks chore/auto-libs; then
+            gh pr merge chore/auto-libs 
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
+
+
       - name: Fetch charm libraries
+        id: fetch-libraries
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
           cd ${{ inputs.charm-path }}
+          pr_title="chore: update charm libraries"; pr_branch="chore/auto-libs"
+          # Get the charm name
+          charm_name=$((yq .name metadata.yaml 2>/dev/null || yq .name charmcraft.yaml) | tr - _)
+          if [[ $charm_name = "" ]]; then echo "Error: can't extract the charm name." && exit 1; fi
+          # For each library not belonging to the charm, check for a major version update
+          #   "lib" would be of the form `charms.prometheus_k8s.v0.prometheus_scrape`
+          for lib in $(find lib/charms/ -type f | grep '.py$' | grep -v "$charm_name" | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
+            # Extract the name of the library, the current major version, and the charm that owns it
+            lib_name=$(cut -d. -f4 <<< "$lib")
+            lib_major=$(cut -d. -f3 <<< "$lib")
+            lib_owner=$(cut -d. -f2 <<< "$lib" | tr _ -)
+            # Get the latest major version of the library from Charmhub
+            latest_major=$(charmcraft list-lib $lib_owner --format=json | jq -r --arg LIBNAME "$lib_name" '.[] | select(.library_name == $LIBNAME) | .api')
+            # If there is a new major version of the library, remove the old one and fetch the new one
+            if [[ $(echo "$lib_major\n$latest_major$" | sort -V | tail -n1 ) != "$lib_major" ]]; then
+              rm "$lib" && charmcraft fetch-lib charms.$(cut -d. -f2 <<< "$lib").$latest_major.$lib_name
+              pr_title="chore: update charm libraries (major)"; pr_branch="chore/auto-libs-major"
+            fi
+          done
+          # Fetch the libraries that have minor version updates
           charmcraft fetch-lib
+          echo "pr_title=$pr_title" >> $GITHUB_OUTPUT
+          echo "pr_branch=$pr_branch" >> $GITHUB_OUTPUT
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"
 
@@ -49,13 +82,16 @@ jobs:
         id: cpr
         with:
           token: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
-          commit-message: "chore: update charm libraries"
+          commit-message: "${{ steps.fetch-libraries.outputs.pr_title }}"
           committer: "Github Actions <github-actions@github.com>"
           author: "Github Actions <github-actions@github.com>"
-          title: "Update charm libraries"
+          title: "${{ steps.fetch-libraries.outputs.pr_title }}"
           body: |
             Automated action to fetch latest version of charm libraries. The branch of this PR 
             will be wiped during the next check. Unless you really know what you're doing, you 
             most likely don't want to push any commits to this branch.
-          branch: "chore/auto-libs"
+
+            The PR will be auto-merged if the CI is green, unless it includes a major library
+            version bump; in that case, manual changes are most likely required.
+          branch: "${{ steps.fetch-libraries.outputs.pr_branch }}"
           delete-branch: true

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Merge any PRs from the automatically generated "chore/auto-libs" branch if the CI is green
+      - name: Merge any pre-existing PRs from the automatically generated "chore/auto-libs" branch if the CI is green
         run: |
           # If a PR from "chore/auto-libs" is open and CI checks are passing, merge it
           is_pr_open="$(gh pr list --head chore/auto-libs --state open --json id --jq 'length')"

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -63,10 +63,9 @@ jobs:
           open_issues_count="$(gh issue list --search 'chore: update libraries to new major versions' --state open --json id --jq 'length')"
           if [[ "$open_issues_count" == "0" && "$issue_body" != "" ]]; then
             issue_body="$(printf "%s\n\n%s\n%s" "This issue was created automatically because a new major version was detected for a charm library." "You should update the following libraries:" "${issue_body}")"
-            echo "$issue_body"
-            # gh issue create \
-            #   --title "chore: update libraries to new major versions" \
-            #   --body "This issue was created automatically because a new major version was detected for a charm library.\n\nYou should update the following libraries:\n${issue_body}"            
+            gh issue create \
+              --title "chore: update libraries to new major versions" \
+              --body "$issue_body"
           fi
           cd "$GITHUB_WORKSPACE"
         env:

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -35,6 +35,15 @@ jobs:
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"
 
+      - name: Import and configure the GPG key for Noctua
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.NOCTUA_GPG_PRIVATE }}
+          passphrase: ${{ secrets.NOCTUA_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Create a PR for local changes
         uses: peter-evans/create-pull-request@v6
         id: cpr

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -107,7 +107,6 @@ jobs:
             will be overwritten during the next check. Unless you really know what you're doing, you 
             most likely don't want to push any commits to this branch.
 
-            The PR will be auto-merged if the CI is green, unless it includes a major library
-            version bump; in that case, manual changes are most likely required.
+            The PR will be auto-merged if the CI is green, on the next iteration of the workflow.
           branch: chore/auto-libs
           delete-branch: true

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -54,11 +54,9 @@ jobs:
             lib_owner=$(cut -d. -f2 <<< "$lib" | tr _ -)
             # Get the latest major version of the library from Charmhub
             latest_major="v$(charmcraft list-lib $lib_owner --format=json | jq -r --arg LIBNAME $lib_name '.[] | select(.library_name == $LIBNAME) | .api')"
-            echo "[debug] + lib_major = $lib_major, latest_major = $latest_major"
-            echo [debug] $(echo "$lib_major\n$latest_major" | sort -V | tail -n1)
             # If there is a new major version of the library, open a new issue
-            if [[ $(echo "$lib_major\n$latest_major" | sort -V | tail -n1 ) != "$lib_major" ]]; then
-              issue_body="${issue_body}- update $lib to $latest_major\n"
+            if [[ $(printf "%s\n%s" "$lib_major" "$latest_major" | sort -V | tail -n1 ) != "$lib_major" ]]; then
+              issue_body=$(printf "%s\n%s" "$issue_body" "- update $lib to $latest_major")
             fi
           done
           # Check if there are already open issues for major library upgrades
@@ -70,7 +68,7 @@ jobs:
             #   --body "This issue was created automatically because a new major version was detected for a charm library.\n\nYou should update the following libraries:\n${issue_body}"            
             echo "--- dry run ---"
             echo "New GitHub Issue created!"
-            echo " body - This issue was created automatically because a new major version was detected for a charm library.\n\nYou should update the following libraries:\n${issue_body}"
+            printf "%s\n%s" "body - This issue was created automatically because a new major version was detected for a charm library.\n\nYou should update the following libraries:" "${issue_body}"
           fi
           cd "$GITHUB_WORKSPACE"
         env:

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -29,19 +29,17 @@ jobs:
 
       - name: Merge update-libs PRs with green CI
         run: |
-          # If CI is passing on PRs from "chore/auto-libs", merge it
+          # If CI checks are passing on a PR from "chore/auto-libs", merge it
           if gh pr checks chore/auto-libs; then
             gh pr merge chore/auto-libs 
           fi
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
 
-
-      - name: Fetch charm libraries
-        id: fetch-libraries
+      - name: Check for major library updates
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
-          cd ${{ inputs.charm-path }}
+          cd "$GITHUB_WORKSPACE/${{ inputs.charm-path }}"
           # Get the charm name
           charm_name=$((yq .name metadata.yaml 2>/dev/null || yq .name charmcraft.yaml) | tr - _)
           if [[ $charm_name = "" ]]; then echo "Error: can't extract the charm name." && exit 1; fi
@@ -61,7 +59,14 @@ jobs:
                 --body "This issue was created automatically because a new major version was detected for a charm library." 
             fi
           done
-          # Fetch the libraries that have minor version updates
+          cd "$GITHUB_WORKSPACE"
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}"
+
+      - name: Fetch charm libraries
+        run: |
+          cd "$GITHUB_WORKSPACE/${{ inputs.charm-path }}"
           charmcraft fetch-lib
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -103,7 +103,7 @@ jobs:
           author: "Noctua <webops+observability-noctua-bot@canonical.com>"
           title: "chore: update charm libraries"
           body: |
-            Automated action to fetch latest version of charm libraries. The branch of this PR 
+            Automated action to fetch the latest minor and major versions of all charm libraries used by this charm. The branch of this PR 
             will be wiped during the next check. Unless you really know what you're doing, you 
             most likely don't want to push any commits to this branch.
 

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -55,7 +55,7 @@ jobs:
             # Get the latest major version of the library from Charmhub
             latest_major=$(charmcraft list-lib $lib_owner --format=json | jq -r --arg LIBNAME "$lib_name" '.[] | select(.library_name == $LIBNAME) | .api')
             # If there is a new major version of the library, open a new issue
-            if [[ $(echo "$lib_major\nv$latest_major$" | sort -V | tail -n1 ) != "$lib_major" ]]; then
+            if [[ $(echo "$lib_major\nv$latest_major" | sort -V | tail -n1 ) != "$lib_major" ]]; then
               issue_body="${issue_body}- update $lib to v$latest_major\n"
             fi
           done

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -61,14 +61,12 @@ jobs:
           done
           # Check if there are already open issues for major library upgrades
           open_issues_count="$(gh issue list --search 'chore: update libraries to new major versions' --state open --json id --jq 'length')"
-          echo "open_issues_count = $open_issues_count , issue_body = $issue_body"
           if [[ "$open_issues_count" == "0" && "$issue_body" != "" ]]; then
+            issue_body="$(printf "%s\n\n%s\n%s" "This issue was created automatically because a new major version was detected for a charm library." "You should update the following libraries:" "${issue_body}")"
+            echo "$issue_body"
             # gh issue create \
             #   --title "chore: update libraries to new major versions" \
             #   --body "This issue was created automatically because a new major version was detected for a charm library.\n\nYou should update the following libraries:\n${issue_body}"            
-            echo "--- dry run ---"
-            echo "New GitHub Issue created!"
-            printf "%s\n%s" "body - This issue was created automatically because a new major version was detected for a charm library.\n\nYou should update the following libraries:" "${issue_body}"
           fi
           cd "$GITHUB_WORKSPACE"
         env:

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -54,7 +54,8 @@ jobs:
             lib_owner=$(cut -d. -f2 <<< "$lib" | tr _ -)
             # Get the latest major version of the library from Charmhub
             latest_major=$(charmcraft list-lib $lib_owner --format=json | jq -r --arg LIBNAME "$lib_name" '.[] | select(.library_name == $LIBNAME) | .api')
-            echo "[debug] lib_major = $lib_major, latest_major = $latest_major"
+            echo "[debug] + lib_major = $lib_major, latest_major = $latest_major"
+            echo "[debug] $(echo $lib_major\nv$latest_major | sort -V | tail -n1)"
             # If there is a new major version of the library, open a new issue
             if [[ $(echo "$lib_major\nv$latest_major" | sort -V | tail -n1 ) != "$lib_major" ]]; then
               issue_body="${issue_body}- update $lib to v$latest_major\n"
@@ -70,6 +71,7 @@ jobs:
             echo "--- dry run ---"
             echo "New GitHub Issue created!"
             echo " body - This issue was created automatically because a new major version was detected for a charm library.\n\nYou should update the following libraries:\n${issue_body}"
+          fi
           cd "$GITHUB_WORKSPACE"
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -54,6 +54,7 @@ jobs:
             lib_owner=$(cut -d. -f2 <<< "$lib" | tr _ -)
             # Get the latest major version of the library from Charmhub
             latest_major=$(charmcraft list-lib $lib_owner --format=json | jq -r --arg LIBNAME "$lib_name" '.[] | select(.library_name == $LIBNAME) | .api')
+            echo "[debug] lib_major = $lib_major, latest_major = $latest_major"
             # If there is a new major version of the library, open a new issue
             if [[ $(echo "$lib_major\nv$latest_major" | sort -V | tail -n1 ) != "$lib_major" ]]; then
               issue_body="${issue_body}- update $lib to v$latest_major\n"

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Merge update-libs PRs with green CI
+      - name: Merge any PRs from the automatically generated "chore/auto-libs" branch if the CI is green
         run: |
           # If a PR from "chore/auto-libs" is open and CI checks are passing, merge it
           is_pr_open="$(gh pr list --head chore/auto-libs --state open --json id --jq 'length')"

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -104,7 +104,7 @@ jobs:
           title: "chore: update charm libraries"
           body: |
             Automated action to fetch the latest minor and major versions of all charm libraries used by this charm. The branch of this PR 
-            will be wiped during the next check. Unless you really know what you're doing, you 
+            will be overwritten during the next check. Unless you really know what you're doing, you 
             most likely don't want to push any commits to this branch.
 
             The PR will be auto-merged if the CI is green, unless it includes a major library

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # If CI checks are passing on a PR from "chore/auto-libs", merge it
           if gh pr checks chore/auto-libs; then
-            gh pr merge chore/auto-libs --auto
+            gh pr merge chore/auto-libs --merge --auto
           fi
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}


### PR DESCRIPTION
This PR achieves three things:
* sign commits made by Noctua (right now they have to be manually signed);
* when `update-libs` PRs are green (e.g., passsing all the tests), they will be auto-merged;
* major library upgrades are detected and an issue is created for them.

---

### Signing commits

To achieve this, I generated a new GPG key for Noctua, and added it as a secret to our repos; the action `crazy-max/ghaction-import-gpg@v6` configures it, and I modified how we use the PR creation workflow to make sure the commit is authored by Noctua, instead of GitHub Actions.

✔️ [Here](https://github.com/canonical/prometheus-pushgateway-k8s-operator/pull/27/commits/e2796d43104cc4dd6aec8552381d828b95b6efaf) is a signed commit showing that this works.

### Auto-merging PRs

To run this on a schedule, I bundled this with the `update-libs` workflow itself; before checking for library updates, the workflow checks for an unmerged `update-libs` PR that is passing all the checks; if present, it merges it.

✔️ [This PR](https://github.com/canonical/mimir-worker-k8s-operator/pull/40) was opened (notice the new description mentioning auto-merge) and merged by Noctua on its own, showing this part works.


### Major Library upgrade

When a charm library has a major upgrade, charms that use it likely require some changes when updating (as major upgrades are breaking). After discussing it, we agreed that opening a failing PR was a bad idea; so we create an issue, which lists which libraries need to be updated to a new major version.

✔️ You can see issues being opened correctly [here](https://github.com/canonical/prometheus-pushgateway-k8s-operator/issues/26).