### PR TITLE
[rock ci] Use yq v4

### DIFF
--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -62,6 +62,9 @@ jobs:
           repository: observability-noctua-bot/oci-factory
           token: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
 
+      # Install the same yq version that is used in oci-factory
+      - run: sudo snap install yq --channel=v4/stable
+
       - name: Update releases in image.yaml
         id: update-releases
         if: steps.changed-files.outputs.all_changed_and_modified_files != ''
@@ -100,7 +103,7 @@ jobs:
             fi
             # Build the final JSON object to update image.yaml
             rock_tags=$(printf '{%s%s%s}' "$patch_tag" "$minor_tag" "$major_tag")
-            upload_item_format='{"source":"%s","commit":"%s","directory":"!!str %s","release":%s}'
+            upload_item_format='{"source":"%s","commit":"%s","directory":"%s","release":%s}'
             upload_item=$(printf "$upload_item_format" \
               "canonical/${{ inputs.rock-name }}-rock" \
               "${{ steps.commit-sha.outputs.commit_sha }}" \

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -100,7 +100,7 @@ jobs:
             fi
             # Build the final JSON object to update image.yaml
             rock_tags=$(printf '{%s%s%s}' "$patch_tag" "$minor_tag" "$major_tag")
-            upload_item_format='{"source":"%s","commit":"%s","directory":"%s","release":%s}'
+            upload_item_format='{"source":"%s","commit":"%s","directory":"!!str %s","release":%s}'
             upload_item=$(printf "$upload_item_format" \
               "canonical/${{ inputs.rock-name }}-rock" \
               "${{ steps.commit-sha.outputs.commit_sha }}" \


### PR DESCRIPTION
## Problem
In our CI, rock version comes from:
```bash
rock_version=$(yq -r '.version' $GITHUB_WORKSPACE/rock/$file)

#...

upload_item_format='{"source":"%s","commit":"%s","directory":"%s","release":%s}'
upload_item=$(printf "$upload_item_format" \
  "canonical/${{ inputs.rock-name }}-rock" \
  "${{ steps.commit-sha.outputs.commit_sha }}" \
  "$rock_version" \
  "$rock_tags" \
)
```

oci-factory CI [failed](https://github.com/canonical/oci-factory/actions/runs/8755600719/job/24030123375#step:6:12) because the version `"0.120"` was parsed as `0.12`.
[Manually adding quotations](https://github.com/canonical/oci-factory/pull/166/commits/a674439512bd25f1ca037438106a168667b24015) helped.

## Solution
Before this PR, our CI specified `runs-on ubuntu:latest` without specifying a yq version.
This PR adds a step for installing yq v4, to [match oci-factory](https://github.com/canonical/oci-factory/blob/b410cdc2ac9fcdd12518e738e223584b076d27d3/.github/workflows/Build-Rock.yaml#L53).