### PR TITLE
feat: make update-lib committer details configurable

### DIFF
--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -128,8 +128,8 @@ jobs:
         with:
           token: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
           commit-message: "chore: update charm libraries"
-          committer: "${{ inputs.commit-email }} <${{ inputs.commit-email }}>"
-          author: "${{ inputs.commit-email }} <${{ inputs.commit-email }}>"
+          committer: "${{ inputs.commit-username }} <${{ inputs.commit-email }}>"
+          author: "${{ inputs.commit-username }} <${{ inputs.commit-email }}>"
           title: "chore: update charm libraries"
           body: |
             Automated action to fetch the latest minor and major versions of all charm libraries used by this charm. The branch of this PR 

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -7,6 +7,16 @@ on:
         default: '.'
         required: false
         type: string
+      commit-username:
+        description: "The username to use for committing the updates on the charm libraries"
+        default: 'Noctua'
+        required: false
+        type: string
+      commit-email:
+        description: "The email address to use for committing the updates on the charm libraries"
+        default: 'webops+observability-noctua-bot@canonical.com'
+        required: false
+        type: string
     secrets:
       CHARMHUB_TOKEN:
         required: false
@@ -118,8 +128,8 @@ jobs:
         with:
           token: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
           commit-message: "chore: update charm libraries"
-          committer: "Noctua <webops+observability-noctua-bot@canonical.com>"
-          author: "Noctua <webops+observability-noctua-bot@canonical.com>"
+          committer: "${{ inputs.commit-email }} <${{ inputs.commit-email }}>"
+          author: "${{ inputs.commit-email }} <${{ inputs.commit-email }}>"
           title: "chore: update charm libraries"
           body: |
             Automated action to fetch the latest minor and major versions of all charm libraries used by this charm. The branch of this PR 


### PR DESCRIPTION
This PR enables the reuse of update-libs GH action from `canonical` org repositories not in observability umbrella. With the current definition, the Noctua bot details will be tried. Since the GPG key of Noctua bot is owned by observability there is no way for other teams to adopt the `charm-update-libs` without the proposed change.