### PR TITLE
add promote train callable workflow

### DIFF
--- a/.github/workflows/charm-promote-train.yaml
+++ b/.github/workflows/charm-promote-train.yaml
@@ -1,0 +1,42 @@
+name: Promote Charm across all risk tracks
+
+on:
+  workflow_call:
+    inputs:
+      charm-path:
+        description: "Path to the charm we want to promote. Defaults to the current working directory."
+        type: string
+        default: '.'
+        required: false
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+
+jobs:
+  promote:
+    name: Promote Charm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Promote Charm from candidate to stable
+        uses: canonical/charming-actions/promote-charm@feature/promote-charm
+        with:
+          charm-path: ${{ inputs.charm-path }}
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          destination-channel: latest/stable
+          origin-channel: latest/candidate
+      - name: Promote Charm from beta to candidate
+        uses: canonical/charming-actions/promote-charm@feature/promote-charm
+        with:
+          charm-path: ${{ inputs.charm-path }}
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          destination-channel: latest/candidate
+          origin-channel: latest/beta
+      - name: Promote Charm from edge to beta
+        uses: canonical/charming-actions/promote-charm@feature/promote-charm
+        with:
+          charm-path: ${{ inputs.charm-path }}
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          destination:channel: latest/beta
+          origin-channel: latest/edge

--- a/.github/workflows/charm-promote.yaml
+++ b/.github/workflows/charm-promote.yaml
@@ -37,11 +37,10 @@ jobs:
             echo "promote-to=stable" >> ${GITHUB_ENV}
           fi
       - name: Promote Charm
-        uses: canonical/charming-actions/release-charm@2.5.0-rc
+        uses: canonical/charming-actions/promote-charm@feature/promote-charm
         with:
           charm-path: ${{ inputs.charm-path }}
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: latest/${{ env.promote-to }}
           origin-channel: latest/${{ env.promote-from }}
           charmcraft-channel: latest/stable


### PR DESCRIPTION
The PR adds a new callable workflow (pointing at the temporary branch `canonical/charming-actions@feature/promote-charm`).

It promotes a single charm across all risk tracks in `latest`; specifically, it promotes:
* `candidate -> stable`
* `beta -> candidate`
* `edge -> beta`