### PR TITLE
feat: cache charmcraft pip dependencies across runs in itests

### DIFF
--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -32,6 +32,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: Setup Charmcraft's pip cache
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/snap/charmcraft/common/cache/charmcraft/
+          key: charmcraft-cache-${{ github.job }}-${{ strategy.job-index }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: charmcraft-cache
       - name: Get IP range
         id: ip_range
         if: ${{ inputs.ip-range == '' }}


### PR DESCRIPTION
The `actions/cache` action persists Charmcraft's pip cache across runs:
* `key` is the name under which the cache entry will be saved **at the end of the job**;
* `restore-keys` needs to (even partially) match a cache key (when finding multiple, it'll pick up the most recent one)

This should slightly speed up our integration tests!