### PR TITLE
fix: use promote-action from charming-actions

### DIFF
--- a/.github/workflows/charm-promote.yaml
+++ b/.github/workflows/charm-promote.yaml
@@ -37,11 +37,10 @@ jobs:
             echo "promote-to=stable" >> ${GITHUB_ENV}
           fi
       - name: Promote Charm
-        uses: canonical/charming-actions/release-charm@2.5.0-rc
+        uses: canonical/charming-actions/promote-charm@2.6.0
         with:
           charm-path: ${{ inputs.charm-path }}
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: latest/${{ env.promote-to }}
           origin-channel: latest/${{ env.promote-from }}
           charmcraft-channel: latest/stable


### PR DESCRIPTION
## Issue

Closes #123.

## Solution

A new action was introduced in **charming-actions** to promote a charm across all bases and architectures. This PR changes the workflow to use that action.

**This is the manual workflow that can be run on each repository to promote a charm**.

It currently hardcodes `latest/` as the track; we'll update it with a track selector in the future :)