### PR TITLE
Update CODEOWNERS to use team instead of individuals

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @abuelodelanada @dstathis @IbraAoad @lucabello @mmkay @pietropasotti @sed-i @simskij
+*       @simskij @canonical/Observability


### PR DESCRIPTION
As a safety just in case, this leaves @simskij mentioned individually in case something is wrong with the team's setup.  This can be removed in future once we know the team worked.