### PR TITLE
add test version of promote train based on charming-actions

### DIFF
--- a/.github/workflows/_charm-promote-train.yaml
+++ b/.github/workflows/_charm-promote-train.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       charm-repo:
-        description: "Repository of the charm to promote. Defaults  to the caller repository."
+        description: "Repository of the charm to promote. Defaults to the caller repository."
         type: string
         default: ${{ github.repository }}
         required: false

--- a/.github/workflows/_charm-promote-train.yaml
+++ b/.github/workflows/_charm-promote-train.yaml
@@ -1,0 +1,77 @@
+name: Promote Charm across all risk tracks
+
+on:
+  workflow_call:
+    inputs:
+      charm-repo:
+        description: "Repository of the charm to promote. Defaults  to the caller repository."
+        type: string
+        default: ${{ github.repository }}
+        required: false
+      charm-path:
+        description: "Path to the charm we want to promote. Defaults to the current working directory."
+        type: string
+        default: '.'
+        required: false
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+
+jobs:
+  promote:
+    name: Promote Charm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.charm-repo }}
+
+      - name: Check which tracks already have a release
+        id: check-tracks
+        run: |
+          cd ${{ inputs.charm-path }}
+          charm_name=$((yq .name metadata.yaml 2>/dev/null || yq .name charmcraft.yaml) | tr - _)
+          status=$(charmcraft status "$charm_name" --format=json)
+          to_stable=$(echo "$status" | jq -r '.[] | select(.track == "latest") | .mappings[].releases[] | select(.channel == "latest/stable") | .status')
+          to_candidate=$(echo "$status" | jq -r '.[] | select(.track == "latest") | .mappings[].releases[] | select(.channel == "latest/candidate") | .status')
+          to_beta=$(echo "$status" | jq -r '.[] | select(.track == "latest") | .mappings[].releases[] | select(.channel == "latest/beta") | .status')
+          echo "to_stable=$to_stable" >> $GITHUB_OUTPUT
+          echo "to_candidate=$to_candidate" >> $GITHUB_OUTPUT
+          echo "to_beta=$to_beta" >> $GITHUB_OUTPUT
+
+      - name: Promote Charm from candidate to stable
+        if: steps.check-tracks.outputs.to_stable == "open"
+        run: |
+          echo "Promoting ${{ matrix.charm-repo }} from latest/candidate to latest/stable"
+          echo "-- wd $(pwd)"
+          echo "-- charm-path ${{ steps.read-charm-path.outputs.charm-path }}"
+        # uses: canonical/charming-actions/promote-charm@2.6.0
+        # with:
+        #   charm-path: ${{ inputs.charm-path }}
+        #   credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        #   origin-channel: latest/candidate
+        #   destination-channel: latest/stable
+      - name: Promote Charm from beta to candidate
+        if: steps.check-tracks.outputs.to_candidate == "open"
+        run: |
+          echo "Promoting ${{ matrix.charm-repo }} from latest/beta to latest/candidate"
+          echo "-- wd $(pwd)"
+          echo "-- charm-path ${{ steps.read-charm-path.outputs.charm-path }}"       # uses: canonical/charming-actions/promote-charm@2.6.0
+        # with:
+        #   charm-path: ${{ inputs.charm-path }}
+        #   credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        #   origin-channel: latest/beta
+        #   destination-channel: latest/candidate
+      - name: Promote Charm from edge to beta
+        if: steps.check-tracks.outputs.to_beta == "open"
+        run: |
+          echo "Promoting ${{ matrix.charm-repo }} from latest/edge to latest/beta"
+          echo "-- wd $(pwd)"
+          echo "-- charm-path ${{ steps.read-charm-path.outputs.charm-path }}"       # uses: canonical/charming-actions/promote-charm@2.6.0
+        # uses: canonical/charming-actions/promote-charm@2.6.0
+        # with:
+        #   charm-path: ${{ inputs.charm-path }}
+        #   credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        #   origin-channel: latest/edge
+        #   destination:channel: latest/beta

--- a/.github/workflows/_local-promote-train.yaml
+++ b/.github/workflows/_local-promote-train.yaml
@@ -23,23 +23,23 @@ jobs:
           - avalanche-k8s-operator
           - blackbox-exporter-k8s-operator
           - catalogue-k8s-operator
-          - cos-configuration-k8s-operator
-          - cos-proxy-operator
-          - grafana-agent-k8s-operator
-          - grafana-agent-operator
-          - grafana-k8s-operator
-          - karma-alertmanager-proxy-k8s-operator
-          - karma-k8s-operator
-          - loki-k8s-operator
-          - mimir-coordinator-k8s-operator
-          - mimir-worker-k8s-operator
-          - prometheus-k8s-operator
-          - prometheus-pushgateway-k8s-operator
-          - prometheus-scrape-config-k8s-operator
-          - prometheus-scrape-target-k8s-operator
-          - tempo-k8s-operator
-          - traefik-k8s-operator
-          - traefik-route-k8s-operator
+          # - cos-configuration-k8s-operator
+          # - cos-proxy-operator
+          # - grafana-agent-k8s-operator
+          # - grafana-agent-operator
+          # - grafana-k8s-operator
+          # - karma-alertmanager-proxy-k8s-operator
+          # - karma-k8s-operator
+          # - loki-k8s-operator
+          # - mimir-coordinator-k8s-operator
+          # - mimir-worker-k8s-operator
+          # - prometheus-k8s-operator
+          # - prometheus-pushgateway-k8s-operator
+          # - prometheus-scrape-config-k8s-operator
+          # - prometheus-scrape-target-k8s-operator
+          # - tempo-k8s-operator
+          # - traefik-k8s-operator
+          # - traefik-route-k8s-operator
     steps:
       - name: Checkout the charm repository
         uses: actions/checkout@v4

--- a/.github/workflows/_local-promote-train.yaml
+++ b/.github/workflows/_local-promote-train.yaml
@@ -6,7 +6,7 @@ on:
       dry-run:
         description: "Don't actually promote the charms, but print the promotions."
         type: boolean
-        default: true
+        default: false
         required: true
     secrets:
       CHARMHUB_TOKEN:

--- a/.github/workflows/_local-release-train.yaml
+++ b/.github/workflows/_local-release-train.yaml
@@ -1,0 +1,78 @@
+name: Promote Charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Don't actually promote the charms, but print the promotions."
+        type: boolean
+        default: true
+        required: true
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+
+jobs:
+  promote:
+    name: Promote Charm
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        charm-repo:
+          - alertmanager-k8s-operator
+          - avalanche-k8s-operator
+          - blackbox-exporter-k8s-operator
+          - catalogue-k8s-operator
+          - cos-configuration-k8s-operator
+          - cos-proxy-operator
+          - grafana-agent-k8s-operator
+          - grafana-agent-operator
+          - grafana-k8s-operator
+          - karma-alertmanager-proxy-k8s-operator
+          - karma-k8s-operator
+          - loki-k8s-operator
+          - mimir-coordinator-k8s-operator
+          - mimir-worker-k8s-operator
+          - prometheus-k8s-operator
+          - prometheus-pushgateway-k8s-operator
+          - prometheus-scrape-config-k8s-operator
+          - prometheus-scrape-target-k8s-operator
+          - tempo-k8s-operator
+          - traefik-k8s-operator
+          - traefik-route-k8s-operator
+    steps:
+      - name: Checkout the charm repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.charm-repo }}
+      - name: Read the charm path from the Promote workflow
+        id: read-charm-path
+        run: |
+          CHARM_PATH=$(yq -r .jobs.promote.with.charm-path .github/workflows/promote.yaml)
+          if [[ "$CHARM_PATH" == "null" ]]; then
+            echo "charm_path='.'" >> $GITHUB_OUTPUT;
+          else
+            echo "charm_path='$CHARM_PATH'" >> $GITHUB_OUTPUT;
+          fi
+
+      - name: (dry run) Promote latest/candidate to latest/stable
+        if: ${{ inputs.dry-run }}
+        run: |
+          echo "Promoting ${{ matrix.charm-repo }} from latest/candidate to latest/stable"
+          echo "-- charm-path ${{ steps.read-charm-path.outputs.charm-path }}"
+
+      - name: Promote latest/candidate to latest/stable
+        if: ${{ ! inputs.dry-run }}
+        # uses: canonical/charming-actions/promote-charm@2.6.0
+        # with:
+        #   charm-path: ${{ inputs.charm-path }}
+        #   credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        #   destination-channel: latest/${{ env.promote-to }}
+        #   origin-channel: latest/${{ env.promote-from }}
+        #   charmcraft-channel: latest/stable
+        run: |
+          # For testing, only pretend to promote the charm
+          # instead of calling the charming-action
+          echo "Promoting ${{ matrix.charm-repo }} from latest/candidate to latest/stable"
+          echo "-- wd $(pwd)"
+          echo "-- charm-path ${{ steps.read-charm-path.outputs.charm-path }}"

--- a/.github/workflows/_local-release-train.yaml
+++ b/.github/workflows/_local-release-train.yaml
@@ -55,24 +55,17 @@ jobs:
             echo "charm_path='$CHARM_PATH'" >> $GITHUB_OUTPUT;
           fi
 
-      - name: (dry run) Promote latest/candidate to latest/stable
+      - name: (dry run) Promote train
         if: ${{ inputs.dry-run }}
         run: |
-          echo "Promoting ${{ matrix.charm-repo }} from latest/candidate to latest/stable"
-          echo "-- charm-path ${{ steps.read-charm-path.outputs.charm-path }}"
-
-      - name: Promote latest/candidate to latest/stable
-        if: ${{ ! inputs.dry-run }}
-        # uses: canonical/charming-actions/promote-charm@2.6.0
-        # with:
-        #   charm-path: ${{ inputs.charm-path }}
-        #   credentials: ${{ secrets.CHARMHUB_TOKEN }}
-        #   destination-channel: latest/${{ env.promote-to }}
-        #   origin-channel: latest/${{ env.promote-from }}
-        #   charmcraft-channel: latest/stable
-        run: |
-          # For testing, only pretend to promote the charm
-          # instead of calling the charming-action
-          echo "Promoting ${{ matrix.charm-repo }} from latest/candidate to latest/stable"
+          echo "Promote train for ${{ matrix.charm-repo }}; woohoo!"
           echo "-- wd $(pwd)"
           echo "-- charm-path ${{ steps.read-charm-path.outputs.charm-path }}"
+
+      - name: Promote train
+        if: ${{ ! inputs.dry-run }}
+        uses: canonical/observability/.github/workflows/_charm-promote-train.yaml@main
+        secrets: inherit
+        with:
+          charm-repo: ${{ matrix.charm-repo }}
+          charm-path: ${{ steps.read-charm-path.outputs.charm-path }}

--- a/.github/workflows/_local-release-train.yaml
+++ b/.github/workflows/_local-release-train.yaml
@@ -1,4 +1,4 @@
-name: Promote Charm
+name: Release Train
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This PR adds a test version of the promote train workflow, with the goal to run the `promote-charm` charming-action for all of our charms, as a one-click workflow starting from the **observability** repository.

This version will currently only print the promotions (to make sure the flow works correctly), and will later be upgraded to use the `promote-charm` action.

The list of charms is currently hard-coded to the list of charms in [releases.juju.is](https://releases.juju.is/?team=Observability), but it could (and probably _should_) be taken from another source of truth.

A better `description` for the action and polishing will come in a future PR.