### PR TITLE
shorten rock EOL to 3 months

### DIFF
--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -78,7 +78,7 @@ jobs:
           all_tags="$existing_tags\n$modified_tags"
           today="$(date)"
           echo "now_epoch=$(date -d now +%s)" >> $GITHUB_OUTPUT  # to create a unique branch name on the fork
-          end_of_life="$(date -d "$today+1 year" +%Y-%m-%d)"
+          end_of_life="$(date -d "$today+3 months" +%Y-%m-%d)"
           yq -i ".upload = []" $GITHUB_WORKSPACE/oci-factory/oci/${{ inputs.rock-name }}/image.yaml
           for file in ${{ steps.changed-files.outputs.all_changed_and_modified_files }}; do
             # For each rock version, build the `upload:` element for image.yaml as a json


### PR DESCRIPTION
As agreed with the Rockcraft team, we're shortening the default EOL for our rocks to 3 months.