### PR TITLE
[adr] Shared URLs between COS-Lite components and external charms

### DIFF
--- a/decision-records/2024-07-16--shared-urls.md
+++ b/decision-records/2024-07-16--shared-urls.md
@@ -1,0 +1,41 @@
+# Shared URLs between COS-Lite components and external charms
+**Date:** 2024-07-16<br/>
+**Authors:** @Abuelodelanada, @sed-i
+
+
+## Context and Problem Statement
+The workload of many charms is a server, that other charmed workloads need to reach.
+Typically, the server URL is "announced" over relation data, but we have different URLs "types" we could announce:
+```
+{HTTP / HTTPS} {internal / ingress} {IP / FQDN}
+```
+Which URL(s) should we announce to other charms?
+
+## Decision
+- Announce no more than one server URL on the same relation interface. I.e. do not announce both internal and external URLs for the same server on the same relation interface.
+- If TLS is enabled, then only announce the HTTPS.
+- If ingress is available, then the ingress (external) URL; otherwise: FQDN (internal). Exceptions:
+  - `ingress` relation: the loadbalanced server URLs will use k8s fqdn address.
+  - `tls-certificates` relation: only ingress charms will render a CSR with their external url; all other charms will render a CSR with k8s fqdn address.
+  - Alertmanager's peer relation: gossip ring will use k8s fqdn address.
+
+## Benefits
+- Charm code does not need to concern itself whether a given relation is in-model or cross-model.
+
+## Disadvantages
+- Ingress (traefik) becomes a single point of failure for in-model traffic.
+- All charms need to trust the CA that signed the ingress. If the trust chain includes a root CA and the charm has ca-certificates installed, then this is a non-issue.
+  Otherwise may need to have a [`receive-ca-cert`](https://github.com/canonical/certificate-transfer-interface/) relation.
+
+## Alternatives considered
+- Annouce the internal URL for in-model relations and the external URL for cross-model relations. Since a charm [cannot always determine if a relation is cross model](https://github.com/canonical/cos-lib/pull/30),
+  this alternative was abandoned.
+
+## History
+During the COS-Lite building process there was a lot of back and forth on the shared URLs (metrics endpoints, datasources endpoints, etc) between COS-Lite components. 
+
+For instance, the very first approach was to use intra-model IPs to build the endpoints that Prometheus was going to scrape. Soon we realised not always the internal IPs were available at the moment the endpoint was built, and that IP changes across an upgrade..
+
+Using intra-model FQDNs emerged as a second approach as the names are predictable at any moment. 
+
+After implementing this second approach, Traefik charm became a reality. The decision was then to use ingress-provided address to build URLs (metrics endpoints, datasource endpoints, etc) if the relation between Traefik and the charm was established, if not use FQDNs.

--- a/decision-records/2024-07-16--shared-urls.md
+++ b/decision-records/2024-07-16--shared-urls.md
@@ -43,7 +43,7 @@ grafana-agent ---|ingress url| prometheus
 - Charm code does not need to concern itself whether a given relation is in-model or cross-model.
 
 ## Disadvantages
-- Ingress (traefik) becomes a single point of failure for in-model traffic.
+- Ingress (traefik) becomes a single point of failure for in-model traffic. This means that if traefik stops working, we not only stop receiving telemetry from charms, but we also stop self-monitoring our own stack.
 - All charms need to trust the CA that signed the ingress. If the trust chain includes a root CA and the charm has ca-certificates installed, then this is a non-issue.
   Otherwise may need to have a [`receive-ca-cert`](https://github.com/canonical/certificate-transfer-interface/) relation.
 

--- a/decision-records/2024-07-16--shared-urls.md
+++ b/decision-records/2024-07-16--shared-urls.md
@@ -5,10 +5,11 @@
 
 ## Context and Problem Statement
 The workload of many charms is a server, that other charmed workloads need to reach.
-Typically, the server URL is "announced" over relation data, but we have different URLs "types" we could announce:
-```
-{HTTP / HTTPS} {internal / ingress} {IP / FQDN}
-```
+Typically, the server URL is "announced" over relation data, but we have different URLs "types" we could announce, for example:
+- app / unit IP (internal)
+- unit's fqdn (internal)
+- ingress url (external)
+
 Which URL(s) should we announce to other charms?
 
 ## Decision

--- a/decision-records/2024-07-16--shared-urls.md
+++ b/decision-records/2024-07-16--shared-urls.md
@@ -19,6 +19,26 @@ Which URL(s) should we announce to other charms?
   - `tls-certificates` relation: only ingress charms will render a CSR with their external url; all other charms will render a CSR with k8s fqdn address.
   - Alertmanager's peer relation: gossip ring will use k8s fqdn address.
 
+```mermaid
+graph LR
+
+subgraph www
+CA
+end
+
+subgraph COS
+CA -.-|external hostname| traefik
+traefik ---|fqdn url| alertmanager
+traefik ---|fqdn url| prometheus
+alertmanager ---|ingress url| prometheus
+alertmanager ---|fqdn url| alertmanager
+self-signed-certs ---|fqdn url| alertmanager
+self-signed-certs ---|fqdn url| prometheus
+end
+
+grafana-agent ---|ingress url| prometheus
+```
+
 ## Benefits
 - Charm code does not need to concern itself whether a given relation is in-model or cross-model.
 


### PR DESCRIPTION
This ADR addresses which server URL to announce over relation data.
Based on the spec by @Abuelodelanada.

This obviates https://github.com/canonical/cos-lib/pull/30.