### PR TITLE
Create a Terraform module for Tempo HA

### DIFF
--- a/.github/workflows/terraform-quality-checks.yaml
+++ b/.github/workflows/terraform-quality-checks.yaml
@@ -1,0 +1,13 @@
+name: Terraform CI
+
+on:
+  workflow_call:
+
+jobs:
+    terraform-lint:
+        name: Terraform lint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: hashicorp/setup-terraform@v3
+            - run: terraform fmt -check -recursive -diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/dist/**
+.terraform*
+*.tfstate*

--- a/terraform/modules/tempo-ha/README.md
+++ b/terraform/modules/tempo-ha/README.md
@@ -24,7 +24,7 @@ The module offers the following configurable inputs:
 
 | Name | Type | Description | Required |
 | - | - | - | - |
-| `channel`| string | Channel that the charms are deployed from | latest/stable |
+| `channel`| string | Channel that the charms are deployed from | latest/edge |
 | `compactor_units`| number | Number of Tempo worker units with compactor role | 1 |
 | `distributor_units`| number | Number of Tempo worker units with distributor role | 1 |
 | `ingester_units`| number | Number of Tempo worker units with ingester role | 1 |
@@ -32,6 +32,7 @@ The module offers the following configurable inputs:
 | `model_name`| string | Name of the model that the charm is deployed on |  |
 | `querier_units`| number | Number of Tempo worker units with querier role | 1 |
 | `query_frontend_units`| number | Number of Tempo worker units with query-frontend role | 1 |
+| `use_tls`| bool | Specify whether to use TLS or not for coordinator-worker communication. By default, TLS is enabled through self-signed-certificates | true |
 
 ### Outputs
 Upon applied, the module exports the following outputs:
@@ -50,6 +51,10 @@ Upon applied, the module exports the following outputs:
 Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
 
 To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`. This would deploy all Tempo HA solution modules in the same model.
+
+### Disable TLS
+
+By default, this Terraform module deploys `self-signed-certificates` to secure traffic between the Tempo coordinator and worker through TLS. To opt-out and choose to disable TLS, you can configure the variable `use_tls` and run `terraform apply -var="model_name=<MODEL_NAME>" -var="use_tls=false" -auto-approve`
 
 ### High Availability 
 

--- a/terraform/modules/tempo-ha/README.md
+++ b/terraform/modules/tempo-ha/README.md
@@ -6,7 +6,7 @@ The HA solution consists of the following Terraform modules:
 - [tempo-coordinator-k8s](https://github.com/canonical/tempo-coordinator-k8s-operator): ingress, cluster coordination, single integration facade.
 - [tempo-worker-k8s](https://github.com/canonical/tempo-worker-k8s-operator): run one or more tempo application components.
 - [s3-integrator](https://github.com/canonical/s3-integrator): facade for S3 storage configurations.
-- [self-signed-certificates](https://github.com/canonical/self-signed-certificates-operator): certificates operator to secure traffik with TLS.
+- [self-signed-certificates](https://github.com/canonical/self-signed-certificates-operator): certificates operator to secure traffic with TLS.
 
 This Terraform module deploys Tempo in its [microservices mode](https://grafana.com/docs/tempo/latest/setup/deployment/#microservices-mode), which runs each one of the required roles in distinct processes. [See](https://discourse.charmhub.io/t/topic/15484) to understand more about Tempo roles.
 
@@ -51,7 +51,7 @@ Users should ensure that Terraform is aware of the `juju_model` dependency of th
 
 To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`. This would deploy all Tempo HA solution modules in the same model.
 
-## High Availability 
+### High Availability 
 
 By default, this Terraform module will deploy each Tempo worker with `1` unit. To configure the module to run `x` units of any worker role, you can run `terraform apply -var="model_name=<MODEL_NAME>" -var="<ROLE>_units=<x>" -auto-approve`.
 See [Tempo worker roles](https://discourse.charmhub.io/t/tempo-worker-roles/15484) for the recommended scale for each role.

--- a/terraform/modules/tempo-ha/README.md
+++ b/terraform/modules/tempo-ha/README.md
@@ -1,0 +1,57 @@
+Terraform module for Tempo HA solution
+
+This is a Terraform module facilitating the deployment of Tempo HA solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+The HA solution consists of the following Terraform modules:
+- [tempo-coordinator-k8s](https://github.com/canonical/tempo-coordinator-k8s-operator): ingress, cluster coordination, single integration facade.
+- [tempo-worker-k8s](https://github.com/canonical/tempo-worker-k8s-operator): run one or more tempo application components.
+- [s3-integrator](https://github.com/canonical/s3-integrator): facade for S3 storage configurations.
+- [self-signed-certificates](https://github.com/canonical/self-signed-certificates-operator): certificates operator to secure traffik with TLS.
+
+This Terraform module deploys Tempo in its [microservices mode](https://grafana.com/docs/tempo/latest/setup/deployment/#microservices-mode), which runs each one of the required roles in distinct processes. [See](https://discourse.charmhub.io/t/topic/15484) to understand more about Tempo roles.
+
+
+> [!NOTE]  
+> `s3-integrator` itself doesn't act as an S3 object storage system. For the HA solution to be functional, `s3-integrator` needs to point to an S3-like storage. See [this guide](https://discourse.charmhub.io/t/cos-lite-docs-set-up-minio/15211) to learn how to connect to an S3-like storage for traces.
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `channel`| string | Channel that the charms are deployed from | latest/stable |
+| `compactor_units`| number | Number of Tempo worker units with compactor role | 1 |
+| `distributor_units`| number | Number of Tempo worker units with distributor role | 1 |
+| `ingester_units`| number | Number of Tempo worker units with ingester role | 1 |
+| `metrics_generator_units`| number | Number of Tempo worker units with metrics-generator role | 1 |
+| `model_name`| string | Name of the model that the charm is deployed on |  |
+| `querier_units`| number | Number of Tempo worker units with querier role | 1 |
+| `query_frontend_units`| number | Number of Tempo worker units with query-frontend role | 1 |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `requires` endpoints |
+
+## Usage
+
+
+### Basic usage
+
+Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
+
+To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`. This would deploy all Tempo HA solution modules in the same model.
+
+## High Availability 
+
+By default, this Terraform module will deploy each Tempo worker with `1` unit. To configure the module to run `x` units of any worker role, you can run `terraform apply -var="model_name=<MODEL_NAME>" -var="<ROLE>_units=<x>" -auto-approve`.
+See [Tempo worker roles](https://discourse.charmhub.io/t/tempo-worker-roles/15484) for the recommended scale for each role.

--- a/terraform/modules/tempo-ha/main.tf
+++ b/terraform/modules/tempo-ha/main.tf
@@ -72,6 +72,7 @@ module "tempo_metrics_generator" {
 }
 
 module "ssc" {
+  count      = var.use_tls ? 1 : 0
   source     = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
   model_name = var.model_name
   channel    = var.channel
@@ -109,6 +110,7 @@ resource "juju_integration" "coordinator_to_s3_integrator" {
 }
 
 resource "juju_integration" "coordinator_to_ssc" {
+  count = var.use_tls ? 1 : 0
   model = var.model_name
 
   application {
@@ -117,7 +119,7 @@ resource "juju_integration" "coordinator_to_ssc" {
   }
 
   application {
-    name     = module.ssc.app_name
+    name     = module.ssc[0].app_name
     endpoint = "certificates"
   }
 }

--- a/terraform/modules/tempo-ha/main.tf
+++ b/terraform/modules/tempo-ha/main.tf
@@ -1,0 +1,207 @@
+module "tempo_coordinator" {
+  source     = "git::https://github.com/canonical/tempo-coordinator-k8s-operator//terraform?ref=OPENG-2685"
+  model_name = var.model_name
+  channel    = var.channel
+}
+
+module "tempo_querier" {
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  app_name   = "tempo-querier"
+  model_name = var.model_name
+  channel    = var.channel
+  config = {
+    role-all     = false
+    role-querier = true
+  }
+  units = var.querier_units
+}
+module "tempo_query_frontend" {
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  app_name   = "tempo-query-frontend"
+  model_name = var.model_name
+  channel    = var.channel
+  config = {
+    role-all            = false
+    role-query-frontend = true
+  }
+  units = var.query_frontend_units
+}
+module "tempo_ingester" {
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  app_name   = "tempo-ingester"
+  model_name = var.model_name
+  channel    = var.channel
+  config = {
+    role-all      = false
+    role-ingester = true
+  }
+  units = var.ingester_units
+}
+module "tempo_distributor" {
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  app_name   = "tempo-distributor"
+  model_name = var.model_name
+  channel    = var.channel
+  config = {
+    role-all         = false
+    role-distributor = true
+  }
+  units = var.distributor_units
+}
+module "tempo_compactor" {
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  app_name   = "tempo-compactor"
+  model_name = var.model_name
+  channel    = var.channel
+  config = {
+    role-all       = false
+    role-compactor = true
+  }
+  units = var.compactor_units
+}
+module "tempo_metrics_generator" {
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  app_name   = "tempo-metrics-generator"
+  model_name = var.model_name
+  channel    = var.channel
+  config = {
+    role-all               = false
+    role-metrics-generator = true
+  }
+  units = var.metrics_generator_units
+}
+
+module "ssc" {
+  source     = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
+  model_name = var.model_name
+  channel    = var.channel
+}
+
+# TODO: Replace s3_integrator resource to use its remote terraform module once available
+resource "juju_application" "s3_integrator" {
+  name = "s3-integrator"
+
+  model = var.model_name
+  trust = true
+
+  charm {
+    name    = "s3-integrator"
+    channel = var.channel
+  }
+  units = 1
+
+}
+
+#Integrations
+
+resource "juju_integration" "coordinator_to_s3_integrator" {
+  model = var.model_name
+
+  application {
+    name     = juju_application.s3_integrator.name
+    endpoint = "s3-credentials"
+  }
+
+  application {
+    name     = module.tempo_coordinator.app_name
+    endpoint = "s3"
+  }
+}
+
+resource "juju_integration" "coordinator_to_ssc" {
+  model = var.model_name
+
+  application {
+    name     = module.tempo_coordinator.app_name
+    endpoint = "certificates"
+  }
+
+  application {
+    name     = module.ssc.app_name
+    endpoint = "certificates"
+  }
+}
+
+resource "juju_integration" "coordinator_to_querier" {
+  model = var.model_name
+
+  application {
+    name     = module.tempo_coordinator.app_name
+    endpoint = "tempo-cluster"
+  }
+
+  application {
+    name     = module.tempo_querier.app_name
+    endpoint = "tempo-cluster"
+  }
+}
+
+resource "juju_integration" "coordinator_to_query_frontend" {
+  model = var.model_name
+
+  application {
+    name     = module.tempo_coordinator.app_name
+    endpoint = "tempo-cluster"
+  }
+
+  application {
+    name     = module.tempo_query_frontend.app_name
+    endpoint = "tempo-cluster"
+  }
+}
+
+resource "juju_integration" "coordinator_to_ingester" {
+  model = var.model_name
+
+  application {
+    name     = module.tempo_coordinator.app_name
+    endpoint = "tempo-cluster"
+  }
+
+  application {
+    name     = module.tempo_ingester.app_name
+    endpoint = "tempo-cluster"
+  }
+}
+
+resource "juju_integration" "coordinator_to_distributor" {
+  model = var.model_name
+
+  application {
+    name     = module.tempo_coordinator.app_name
+    endpoint = "tempo-cluster"
+  }
+
+  application {
+    name     = module.tempo_distributor.app_name
+    endpoint = "tempo-cluster"
+  }
+}
+
+resource "juju_integration" "coordinator_to_compactor" {
+  model = var.model_name
+
+  application {
+    name     = module.tempo_coordinator.app_name
+    endpoint = "tempo-cluster"
+  }
+
+  application {
+    name     = module.tempo_compactor.app_name
+    endpoint = "tempo-cluster"
+  }
+}
+
+resource "juju_integration" "coordinator_to_metrics_generator" {
+  model = var.model_name
+
+  application {
+    name     = module.tempo_coordinator.app_name
+    endpoint = "tempo-cluster"
+  }
+
+  application {
+    name     = module.tempo_metrics_generator.app_name
+    endpoint = "tempo-cluster"
+  }
+}

--- a/terraform/modules/tempo-ha/main.tf
+++ b/terraform/modules/tempo-ha/main.tf
@@ -1,11 +1,11 @@
 module "tempo_coordinator" {
-  source     = "git::https://github.com/canonical/tempo-coordinator-k8s-operator//terraform?ref=OPENG-2685"
+  source     = "git::https://github.com/canonical/tempo-coordinator-k8s-operator//terraform"
   model_name = var.model_name
   channel    = var.channel
 }
 
 module "tempo_querier" {
-  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
   app_name   = "tempo-querier"
   model_name = var.model_name
   channel    = var.channel
@@ -16,7 +16,7 @@ module "tempo_querier" {
   units = var.querier_units
 }
 module "tempo_query_frontend" {
-  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
   app_name   = "tempo-query-frontend"
   model_name = var.model_name
   channel    = var.channel
@@ -27,7 +27,7 @@ module "tempo_query_frontend" {
   units = var.query_frontend_units
 }
 module "tempo_ingester" {
-  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
   app_name   = "tempo-ingester"
   model_name = var.model_name
   channel    = var.channel
@@ -38,7 +38,7 @@ module "tempo_ingester" {
   units = var.ingester_units
 }
 module "tempo_distributor" {
-  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
   app_name   = "tempo-distributor"
   model_name = var.model_name
   channel    = var.channel
@@ -49,7 +49,7 @@ module "tempo_distributor" {
   units = var.distributor_units
 }
 module "tempo_compactor" {
-  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
   app_name   = "tempo-compactor"
   model_name = var.model_name
   channel    = var.channel
@@ -60,7 +60,7 @@ module "tempo_compactor" {
   units = var.compactor_units
 }
 module "tempo_metrics_generator" {
-  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform?ref=OPENG-2685"
+  source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
   app_name   = "tempo-metrics-generator"
   model_name = var.model_name
   channel    = var.channel

--- a/terraform/modules/tempo-ha/outputs.tf
+++ b/terraform/modules/tempo-ha/outputs.tf
@@ -1,0 +1,12 @@
+output "app_names" {
+  value = {
+    tempo_coordinator       = module.tempo_coordinator.app_name,
+    tempo_querier           = module.tempo_querier.app_name,
+    tempo_query_frontend    = module.tempo_query_frontend.app_name,
+    tempo_ingester          = module.tempo_ingester.app_name,
+    tempo_distributor       = module.tempo_distributor.app_name,
+    tempo_compactor         = module.tempo_compactor.app_name,
+    tempo_metrics_generator = module.tempo_metrics_generator.app_name,
+    s3_integrator           = juju_application.s3_integrator.name,
+  }
+}

--- a/terraform/modules/tempo-ha/outputs.tf
+++ b/terraform/modules/tempo-ha/outputs.tf
@@ -1,12 +1,19 @@
 output "app_names" {
-  value = {
-    tempo_coordinator       = module.tempo_coordinator.app_name,
-    tempo_querier           = module.tempo_querier.app_name,
-    tempo_query_frontend    = module.tempo_query_frontend.app_name,
-    tempo_ingester          = module.tempo_ingester.app_name,
-    tempo_distributor       = module.tempo_distributor.app_name,
-    tempo_compactor         = module.tempo_compactor.app_name,
-    tempo_metrics_generator = module.tempo_metrics_generator.app_name,
-    s3_integrator           = juju_application.s3_integrator.name,
-  }
+  value = merge(
+    {
+      tempo_coordinator       = module.tempo_coordinator.app_name,
+      tempo_querier           = module.tempo_querier.app_name,
+      tempo_query_frontend    = module.tempo_query_frontend.app_name,
+      tempo_ingester          = module.tempo_ingester.app_name,
+      tempo_distributor       = module.tempo_distributor.app_name,
+      tempo_compactor         = module.tempo_compactor.app_name,
+      tempo_metrics_generator = module.tempo_metrics_generator.app_name,
+      s3_integrator           = juju_application.s3_integrator.name,
+    },
+    var.use_tls ? {
+      self_signed_certificates = module.ssc[0].app_name
+    } : {}
+  )
+
+
 }

--- a/terraform/modules/tempo-ha/variables.tf
+++ b/terraform/modules/tempo-ha/variables.tf
@@ -1,0 +1,72 @@
+variable "channel" {
+  description = "Charms channel"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "compactor_units" {
+  description = "Number of Tempo worker units with compactor role"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.compactor_units >= 1
+    error_message = "The number of units must be greater than or equal to 1."
+  }
+}
+
+variable "distributor_units" {
+  description = "Number of Tempo worker units with distributor role"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.distributor_units >= 1
+    error_message = "The number of units must be greater than or equal to 1."
+  }
+}
+
+variable "ingester_units" {
+  description = "Number of Tempo worker units with ingester role"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.ingester_units >= 1
+    error_message = "The number of units must be greater than or equal to 1."
+  }
+}
+
+variable "metrics_generator_units" {
+  description = "Number of Tempo worker units with metrics-generator role"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.metrics_generator_units >= 1
+    error_message = "The number of units must be greater than or equal to 1."
+  }
+}
+
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "querier_units" {
+  description = "Number of Tempo worker units with querier role"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.querier_units >= 1
+    error_message = "The number of units must be greater than or equal to 1."
+  }
+}
+variable "query_frontend_units" {
+  description = "Number of Tempo worker units with query-frontend role"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.query_frontend_units >= 1
+    error_message = "The number of units must be greater than or equal to 1."
+  }
+}
+
+

--- a/terraform/modules/tempo-ha/variables.tf
+++ b/terraform/modules/tempo-ha/variables.tf
@@ -1,7 +1,7 @@
 variable "channel" {
   description = "Charms channel"
   type        = string
-  default     = "latest/stable"
+  default     = "latest/edge"
 }
 
 variable "compactor_units" {
@@ -69,4 +69,9 @@ variable "query_frontend_units" {
   }
 }
 
+variable "use_tls" {
+  description = "Specify whether to use TLS or not for coordinator-worker communication. By default, TLS is enabled through self-signed-certificates"
+  type        = bool
+  default     = true
+}
 

--- a/terraform/modules/tempo-ha/versions.tf
+++ b/terraform/modules/tempo-ha/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}


### PR DESCRIPTION
Add a terraform module for Tempo HA in its `microservices` mode of operation. The Terraform module will deploy `tempo-coordinator`, `tempo-worker`, `s3-integrator`, `self-signed-certificates` modules.

## Context
https://github.com/canonical/mimir-worker-k8s-operator/pull/74
https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit

## Testing Considerations
Install terraform on your machine
`cd terraform/modules/tempo-ha/ && terrform init && terraform apply` 

