### PR TITLE
Fix stale module references

### DIFF
--- a/terraform/modules/cos/README.md
+++ b/terraform/modules/cos/README.md
@@ -4,7 +4,7 @@ This is a Terraform module facilitating the deployment of COS HA solution, using
 
 The HA solution consists of the following Terraform modules:
 - [grafana-k8s](https://github.com/canonical/grafana-k8s-operator): Visualization, monitoring,and dashboards.
-- [mimir](https://github.com/canonical/observability/tree/cos-ha/terraform/modules/mimir): Storage, metrics, and scalability.
+- [mimir](https://github.com/canonical/observability/tree/main/terraform/modules/mimir): Storage, metrics, and scalability.
 - [s3-integrator](https://github.com/canonical/s3-integrator): facade for S3 storage configurations.
 - [self-signed-certificates](https://github.com/canonical/self-signed-certificates-operator): certificates operator to secure traffic with TLS.
 

--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -13,13 +13,13 @@ module "grafana" {
 }
 
 module "loki" {
-  source      = "git::https://github.com/canonical/observability//terraform/modules/loki?ref=cos-ha"
+  source      = "git::https://github.com/canonical/observability//terraform/modules/loki"
   model_name  = var.model_name
   channel     = var.channel
 }
 
 module "mimir" {
-  source      = "git::https://github.com/canonical/observability//terraform/modules/mimir?ref=cos-ha"
+  source      = "git::https://github.com/canonical/observability//terraform/modules/mimir"
   model_name  = var.model_name
   channel     = var.channel
 }
@@ -32,7 +32,7 @@ module "ssc" {
 }
 
 module "tempo" {
-  source      = "git::https://github.com/canonical/observability//terraform/modules/tempo?ref=cos-ha"
+  source      = "git::https://github.com/canonical/observability//terraform/modules/tempo"
   model_name  = var.model_name
   channel     = var.channel
 }


### PR DESCRIPTION
remove any references to branch `cos-ha` and make them point to the default (main). 