### PR TITLE
Fix .gitignore for TF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
-.terraform.lock.hclvenv
+.terraform.lock.hcl
 
 venv


### PR DESCRIPTION
I think this was a typo since `.terraform.lock.hcl` files are generated by TF