### PR TITLE
[tf] Update the outputs.tf with endpoints nomenclature

### DIFF
--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -53,12 +53,12 @@ resource "juju_integration" "mimir-grafana-dashboards-provider" {
 
   application {
     name     = module.mimir.app_names.mimir_coordinator
-    endpoint = module.mimir.provides.grafana_dashboards_provider
+    endpoint = module.mimir.endpoints.grafana_dashboards_provider
   }
 
   application {
     name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_dashboard
+    endpoint = module.grafana.endpoints.grafana_dashboard
   }
 }
 
@@ -67,12 +67,12 @@ resource "juju_integration" "mimir-grafana-source" {
 
   application {
     name     = module.mimir.app_names.mimir_coordinator
-    endpoint = module.mimir.provides.grafana_source
+    endpoint = module.mimir.endpoints.grafana_source
   }
 
   application {
     name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_source
+    endpoint = module.grafana.endpoints.grafana_source
   }
 }
 
@@ -83,12 +83,12 @@ resource "juju_integration" "loki-grafana-dashboards-provider" {
 
   application {
     name     = module.loki.app_names.loki_coordinator
-    endpoint = module.loki.provides.grafana_dashboards_provider
+    endpoint = module.loki.endpoints.grafana_dashboards_provider
   }
 
   application {
     name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_dashboard
+    endpoint = module.grafana.endpoints.grafana_dashboard
   }
 }
 
@@ -97,12 +97,12 @@ resource "juju_integration" "loki-grafana-source" {
 
   application {
     name     = module.loki.app_names.loki_coordinator
-    endpoint = module.loki.provides.grafana_source
+    endpoint = module.loki.endpoints.grafana_source
   }
 
   application {
     name     = module.grafana.app_name
-    endpoint = module.grafana.requires.grafana_source
+    endpoint = module.grafana.endpoints.grafana_source
   }
 }
 
@@ -113,12 +113,12 @@ resource "juju_integration" "grafana-catalogue" {
 
   application {
     name     = module.catalogue.app_name
-    endpoint = module.catalogue.provides.catalogue
+    endpoint = module.catalogue.endpoints.catalogue
   }
 
   application {
     name     = module.grafana.app_name
-    endpoint = module.grafana.requires.catalogue
+    endpoint = module.grafana.endpoints.catalogue
   }
 }
 
@@ -129,12 +129,12 @@ resource "juju_integration" "catalogue-ingress" {
 
   application {
     name     = module.traefik.app_name
-    endpoint = module.traefik.provides.ingress
+    endpoint = module.traefik.endpoints.ingress
   }
 
   application {
     name     = module.catalogue.app_name
-    endpoint = module.catalogue.requires.ingress
+    endpoint = module.catalogue.endpoints.ingress
   }
 }
 
@@ -143,12 +143,12 @@ resource "juju_integration" "grafana-ingress" {
 
   application {
     name     = module.traefik.app_name
-    endpoint = module.traefik.provides.traefik_route
+    endpoint = module.traefik.endpoints.traefik_route
   }
 
   application {
     name     = module.grafana.app_name
-    endpoint = module.grafana.requires.ingress
+    endpoint = module.grafana.endpoints.ingress
   }
 }
 
@@ -157,11 +157,11 @@ resource "juju_integration" "loki-ingress" {
 
   application {
     name     = module.traefik.app_name
-    endpoint = module.traefik.provides.ingress
+    endpoint = module.traefik.endpoints.ingress
   }
 
   application {
     name     = module.loki.app_names.loki_coordinator
-    endpoint = module.loki.requires.ingress
+    endpoint = module.loki.endpoints.ingress
   }
 }

--- a/terraform/modules/loki/outputs.tf
+++ b/terraform/modules/loki/outputs.tf
@@ -12,17 +12,19 @@ output "app_names" {
 
 output "endpoints" {
   value = {
-    alertmanager                = "alertmanager",
-    certificates                = "certificates",
+    # Requires
+    alertmanager     = "alertmanager",
+    certificates     = "certificates",
+    ingress          = "ingress",
+    logging_consumer = "logging-consumer",
+    s3               = "s3",
+    tracing          = "tracing",
+    # Provides
     grafana_dashboards_provider = "grafana-dashboards-provider",
     grafana_source              = "grafana-source",
-    ingress                     = "ingress",
     logging                     = "logging",
-    logging_consumer            = "logging-consumer",
     loki_cluster                = "loki-cluster",
     receive_remote_write        = "receive-remote-write",
-    s3                          = "s3",
     self_metrics_endpoint       = "self-metrics-endpoint",
-    tracing                     = "tracing",
   }
 }

--- a/terraform/modules/loki/outputs.tf
+++ b/terraform/modules/loki/outputs.tf
@@ -10,24 +10,19 @@ output "app_names" {
   )
 }
 
-output "requires" {
+output "endpoints" {
   value = {
-    alertmanager     = "alertmanager",
-    certificates     = "certificates",
-    ingress          = "ingress",
-    logging_consumer = "logging-consumer",
-    s3               = "s3",
-    tracing          = "tracing",
-  }
-}
-
-output "provides" {
-  value = {
+    alertmanager                = "alertmanager",
+    certificates                = "certificates",
     grafana_dashboards_provider = "grafana-dashboards-provider",
     grafana_source              = "grafana-source",
+    ingress                     = "ingress",
     logging                     = "logging",
+    logging_consumer            = "logging-consumer",
     loki_cluster                = "loki-cluster",
     receive_remote_write        = "receive-remote-write",
+    s3                          = "s3",
     self_metrics_endpoint       = "self-metrics-endpoint",
+    tracing                     = "tracing",
   }
 }

--- a/terraform/modules/loki/outputs.tf
+++ b/terraform/modules/loki/outputs.tf
@@ -1,11 +1,11 @@
 output "app_names" {
   value = merge(
     {
-      loki_s3_integrator  = juju_application.s3_integrator.name,
-      loki_coordinator    = module.loki_coordinator.app_name,
-      loki_backend        = module.loki_backend.app_name,
-      loki_read           = module.loki_read.app_name,
-      loki_write          = module.loki_write.app_name,
+      loki_s3_integrator = juju_application.s3_integrator.name,
+      loki_coordinator   = module.loki_coordinator.app_name,
+      loki_backend       = module.loki_backend.app_name,
+      loki_read          = module.loki_read.app_name,
+      loki_write         = module.loki_write.app_name,
     }
   )
 }

--- a/terraform/modules/mimir/outputs.tf
+++ b/terraform/modules/mimir/outputs.tf
@@ -18,22 +18,17 @@ output "app_names" {
   )
 }
 
-output "requires" {
+output "endpoints" {
   value = {
-    certificates     = "certificates",
-    ingress          = "ingress",
-    logging_consumer = "logging-consumer",
-    s3               = "s3",
-    tracing          = "tracing",
-  }
-}
-
-output "provides" {
-  value = {
+    certificates                = "certificates",
     grafana_dashboards_provider = "grafana-dashboards-provider",
     grafana_source              = "grafana-source",
+    ingress                     = "ingress",
+    logging_consumer            = "logging-consumer",
     mimir_cluster               = "mimir-cluster",
     receive_remote_write        = "receive-remote-write",
+    s3                          = "s3",
     self_metrics_endpoint       = "self-metrics-endpoint",
+    tracing                     = "tracing",
   }
 }

--- a/terraform/modules/mimir/outputs.tf
+++ b/terraform/modules/mimir/outputs.tf
@@ -20,15 +20,17 @@ output "app_names" {
 
 output "endpoints" {
   value = {
-    certificates                = "certificates",
+    # Requires
+    certificates     = "certificates",
+    ingress          = "ingress",
+    logging_consumer = "logging-consumer",
+    s3               = "s3",
+    tracing          = "tracing",
+    # Provides
     grafana_dashboards_provider = "grafana-dashboards-provider",
     grafana_source              = "grafana-source",
-    ingress                     = "ingress",
-    logging_consumer            = "logging-consumer",
     mimir_cluster               = "mimir-cluster",
     receive_remote_write        = "receive-remote-write",
-    s3                          = "s3",
     self_metrics_endpoint       = "self-metrics-endpoint",
-    tracing                     = "tracing",
   }
 }

--- a/terraform/modules/tempo/outputs.tf
+++ b/terraform/modules/tempo/outputs.tf
@@ -1,6 +1,7 @@
 output "app_names" {
   value = merge(
     {
+      tempo_s3_integrator     = juju_application.s3_integrator.name,
       tempo_coordinator       = module.tempo_coordinator.app_name,
       tempo_querier           = module.tempo_querier.app_name,
       tempo_query_frontend    = module.tempo_query_frontend.app_name,
@@ -8,9 +9,12 @@ output "app_names" {
       tempo_distributor       = module.tempo_distributor.app_name,
       tempo_compactor         = module.tempo_compactor.app_name,
       tempo_metrics_generator = module.tempo_metrics_generator.app_name,
-      tempo_s3_integrator           = juju_application.s3_integrator.name,
     }
   )
+}
 
-
+output "endpoints" {
+  value = {
+    tempo_cluster = "tempo-cluster"
+  }
 }

--- a/terraform/modules/tempo/outputs.tf
+++ b/terraform/modules/tempo/outputs.tf
@@ -15,6 +15,8 @@ output "app_names" {
 
 output "endpoints" {
   value = {
+    # Requires
+    # Provides
     tempo_cluster = "tempo-cluster"
   }
 }


### PR DESCRIPTION
# Summary
To remove implementation detail of the TF module when another module inherits it, it makes sense to replace the `requires` and `provides` output variables with `endpoints`.

Tandem PRs:

- https://github.com/canonical/catalogue-k8s-operator/pull/145
- https://github.com/canonical/grafana-k8s-operator/pull/356
- https://github.com/canonical/traefik-k8s-operator/pull/421
- https://github.com/canonical/loki-coordinator-k8s-operator/pull/20
- https://github.com/canonical/loki-worker-k8s-operator/pull/32
- https://github.com/canonical/mimir-coordinator-k8s-operator/pull/86
- https://github.com/canonical/mimir-worker-k8s-operator/pull/81
- https://github.com/canonical/tempo-coordinator-k8s-operator/pull/71
- https://github.com/canonical/tempo-worker-k8s-operator/pull/49

# Testing
This was validated locally by changing the module references to my local FS and running `terraform validate` to ensure the endpoints are correctly referenced