### PR TITLE
Conditional uv vs. tox tests for quality-checks.yaml (Just)

### DIFF
--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python3 -m pip install tox
           sudo snap install --classic astral-uv
-          sudo apt install just
+          sudo apt-get install -y just
       - name: Run linters
         run: |
           cd ${{ inputs.charm-path }}

--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -28,5 +28,6 @@ jobs:
           if [ -f tox.ini ]; then
             tox -vve lint
           else
+            sudo snap install --classic astral-uv
             make lint
           fi

--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -23,4 +23,10 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run linters
-        run: cd ${{ inputs.charm-path }} && tox -vve lint
+        run: |
+          cd ${{ inputs.charm-path }}
+          if [ -f tox.ini ]; then
+            tox -vve lint
+          else
+            make lint
+          fi

--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
         run: |
           python3 -m pip install tox
           sudo snap install --classic astral-uv
-          sudo apt-get install -y just
+          sudo apt install -y just
       - name: Run linters
         run: |
           cd ${{ inputs.charm-path }}

--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -24,7 +24,8 @@ jobs:
         run: |
           python3 -m pip install tox
           sudo snap install --classic astral-uv
+          sudo apt install just
       - name: Run linters
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve lint || make lint
+          [ -f tox.ini ] && tox -vve lint || just lint

--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -21,13 +21,10 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: python3 -m pip install tox
+        run: |
+          python3 -m pip install tox
+          sudo snap install --classic astral-uv
       - name: Run linters
         run: |
           cd ${{ inputs.charm-path }}
-          if [ -f tox.ini ]; then
-            tox -vve lint
-          else
-            sudo snap install --classic astral-uv
-            make lint
-          fi
+          [ -f tox.ini ] && tox -vve lint || make lint

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -64,22 +64,22 @@ jobs:
           charmcraft-channel: "${{ inputs.charmcraft-channel }}"
   static-analysis:
     name: Static Analysis
-    uses: canonical/observability/.github/workflows/_charm-static-analysis.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-static-analysis.yaml@feature/uv-ci-just
     with:
       charm-path: "${{ inputs.charm-path }}"
   linting:
     name: Linting
-    uses: canonical/observability/.github/workflows/_charm-linting.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-linting.yaml@feature/uv-ci-just
     with:
       charm-path: "${{ inputs.charm-path }}"
   unit-test:
     name: Unit Tests
-    uses: canonical/observability/.github/workflows/_charm-tests-unit.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-tests-unit.yaml@feature/uv-ci-just
     with:
       charm-path: "${{ inputs.charm-path }}"
   scenario-test:
     name: Scenario Tests
-    uses: canonical/observability/.github/workflows/_charm-tests-scenario.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-tests-scenario.yaml@feature/uv-ci-just
     with:
       charm-path: "${{ inputs.charm-path }}"
   integration-test:
@@ -89,7 +89,7 @@ jobs:
       - linting
       - unit-test
       - scenario-test
-    uses: canonical/observability/.github/workflows/_charm-tests-integration.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-tests-integration.yaml@feature/uv-ci-just
     with:
       charm-path: "${{ inputs.charm-path }}"
       provider: "${{ inputs.provider }}"

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -64,7 +64,7 @@ jobs:
           charmcraft-channel: "${{ inputs.charmcraft-channel }}"
   static-analysis:
     name: Static Analysis
-    uses: canonical/observability/.github/workflows/_charm-static-analysis.yaml@main
+    uses: canonical/observability/.github/workflows/_charm-static-analysis.yaml@feature/uv-ci-make
     with:
       charm-path: "${{ inputs.charm-path }}"
   linting:
@@ -79,7 +79,7 @@ jobs:
       charm-path: "${{ inputs.charm-path }}"
   scenario-test:
     name: Scenario Tests
-    uses: canonical/observability/.github/workflows/_charm-tests-scenario.yaml@main
+    uses: canonical/observability/.github/workflows/_charm-tests-scenario.yaml@feature/uv-ci-make
     with:
       charm-path: "${{ inputs.charm-path }}"
   integration-test:

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -64,7 +64,7 @@ jobs:
           charmcraft-channel: "${{ inputs.charmcraft-channel }}"
   static-analysis:
     name: Static Analysis
-    uses: canonical/observability/.github/workflows/_charm-static-analysis.yaml@main
+    uses: canonical/observability/.github/workflows/_charm-static-analysis.yaml@feature/uv-ci-make
     with:
       charm-path: "${{ inputs.charm-path }}"
   linting:

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -79,7 +79,7 @@ jobs:
       charm-path: "${{ inputs.charm-path }}"
   scenario-test:
     name: Scenario Tests
-    uses: canonical/observability/.github/workflows/_charm-tests-scenario.yaml@main
+    uses: canonical/observability/.github/workflows/_charm-tests-scenario.yaml@feature/uv-ci-make
     with:
       charm-path: "${{ inputs.charm-path }}"
   integration-test:

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -69,12 +69,12 @@ jobs:
       charm-path: "${{ inputs.charm-path }}"
   linting:
     name: Linting
-    uses: canonical/observability/.github/workflows/_charm-linting.yaml@main
+    uses: canonical/observability/.github/workflows/_charm-linting.yaml@feature/uv-ci-make
     with:
       charm-path: "${{ inputs.charm-path }}"
   unit-test:
     name: Unit Tests
-    uses: canonical/observability/.github/workflows/_charm-tests-unit.yaml@main
+    uses: canonical/observability/.github/workflows/_charm-tests-unit.yaml@feature/uv-ci-make
     with:
       charm-path: "${{ inputs.charm-path }}"
   scenario-test:
@@ -89,7 +89,7 @@ jobs:
       - linting
       - unit-test
       - scenario-test
-    uses: canonical/observability/.github/workflows/_charm-tests-integration.yaml@main
+    uses: canonical/observability/.github/workflows/_charm-tests-integration.yaml@feature/uv-ci-make
     with:
       charm-path: "${{ inputs.charm-path }}"
       provider: "${{ inputs.provider }}"

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -64,22 +64,22 @@ jobs:
           charmcraft-channel: "${{ inputs.charmcraft-channel }}"
   static-analysis:
     name: Static Analysis
-    uses: canonical/observability/.github/workflows/_charm-static-analysis.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-static-analysis.yaml@main
     with:
       charm-path: "${{ inputs.charm-path }}"
   linting:
     name: Linting
-    uses: canonical/observability/.github/workflows/_charm-linting.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-linting.yaml@main
     with:
       charm-path: "${{ inputs.charm-path }}"
   unit-test:
     name: Unit Tests
-    uses: canonical/observability/.github/workflows/_charm-tests-unit.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-tests-unit.yaml@main
     with:
       charm-path: "${{ inputs.charm-path }}"
   scenario-test:
     name: Scenario Tests
-    uses: canonical/observability/.github/workflows/_charm-tests-scenario.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-tests-scenario.yaml@main
     with:
       charm-path: "${{ inputs.charm-path }}"
   integration-test:
@@ -89,7 +89,7 @@ jobs:
       - linting
       - unit-test
       - scenario-test
-    uses: canonical/observability/.github/workflows/_charm-tests-integration.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-tests-integration.yaml@main
     with:
       charm-path: "${{ inputs.charm-path }}"
       provider: "${{ inputs.provider }}"

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -39,4 +39,11 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run static analysis (charm)
-        run: cd ${{ inputs.charm-path }} && tox -vve static-charm
+        run: |
+          cd ${{ inputs.charm-path }}
+          if [ -f tox.ini ]; then
+            tox -vve static-charm
+          else
+            sudo snap install --classic astral-uv
+            make static
+          fi

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -23,7 +23,14 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run static analysis for /lib for 3.8
-        run: cd ${{ inputs.charm-path }} && tox -vve static-lib
+        run: |
+          cd ${{ inputs.charm-path }}
+          if [ -f tox.ini ]; then
+            tox -vve static-lib
+          else
+            sudo snap install --classic astral-uv
+            make static
+          fi
   static-charm:
     name: Static Analysis of Charm
     runs-on: ubuntu-latest

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -21,16 +21,14 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: python3 -m pip install tox
+        run: |
+          python3 -m pip install tox
+          sudo snap install --classic astral-uv
+          sudo apt install just
       - name: Run static analysis for /lib for 3.8
         run: |
           cd ${{ inputs.charm-path }}
-          if [ -f tox.ini ]; then
-            tox -vve static-lib
-          else
-            sudo snap install --classic astral-uv
-            make static
-          fi
+          [ -f tox.ini ] && tox -vve static-lib || just static
   static-charm:
     name: Static Analysis of Charm
     runs-on: ubuntu-latest
@@ -47,7 +45,8 @@ jobs:
         run: |
           python3 -m pip install tox
           sudo snap install --classic astral-uv
+          sudo apt install just
       - name: Run static analysis (charm)
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve static-charm || make static
+          [ -f tox.ini ] && tox -vve static-charm || just static

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python3 -m pip install tox
           sudo snap install --classic astral-uv
-          sudo apt install just
+          sudo apt-get install -y just
       - name: Run static analysis for /lib for 3.8
         run: |
           cd ${{ inputs.charm-path }}
@@ -45,7 +45,7 @@ jobs:
         run: |
           python3 -m pip install tox
           sudo snap install --classic astral-uv
-          sudo apt install just
+          sudo apt-get install -y just
       - name: Run static analysis (charm)
         run: |
           cd ${{ inputs.charm-path }}

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -44,13 +44,10 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: python3 -m pip install tox
+        run: |
+          python3 -m pip install tox
+          sudo snap install --classic astral-uv
       - name: Run static analysis (charm)
         run: |
           cd ${{ inputs.charm-path }}
-          if [ -f tox.ini ]; then
-            tox -vve static-charm
-          else
-            sudo snap install --classic astral-uv
-            make static
-          fi
+          [ -f tox.ini ] && tox -vve static-charm || make static

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   static-lib:
     name: Static Analysis of Libs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,14 +24,14 @@ jobs:
         run: |
           python3 -m pip install tox
           sudo snap install --classic astral-uv
-          sudo apt-get install -y just
+          sudo apt install -y just
       - name: Run static analysis for /lib for 3.8
         run: |
           cd ${{ inputs.charm-path }}
           [ -f tox.ini ] && tox -vve static-lib || just static
   static-charm:
     name: Static Analysis of Charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
         run: |
           python3 -m pip install tox
           sudo snap install --classic astral-uv
-          sudo apt-get install -y just
+          sudo apt install -y just
       - name: Run static analysis (charm)
         run: |
           cd ${{ inputs.charm-path }}

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -68,10 +68,11 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install --classic astral-uv
+          sudo apt install just
       - name: Run integration tests
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve integration || make integration
+          [ -f tox.ini ] && tox -vve integration || just integration
       - name: Dump logs
         if: failure()
         uses: canonical/charming-actions/dump-logs@main

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -66,7 +66,13 @@ jobs:
           microk8s-addons: "hostpath-storage dns metallb:${{ inputs.ip-range || steps.ip_range.outputs.ip_range }}"
           charmcraft-channel: "${{ inputs.charmcraft-channel }}"
       - name: Run integration tests
-        run: cd ${{ inputs.charm-path }} && tox -vve integration
+        run: |
+          cd ${{ inputs.charm-path }}
+          if [ -f tox.ini ]; then
+            tox -vve integration
+          else  
+            make unit
+          fi
       - name: Dump logs
         if: failure()
         uses: canonical/charming-actions/dump-logs@main

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install --classic astral-uv
-          sudo apt install just
+          sudo apt-get install -y just
       - name: Run integration tests
         run: |
           cd ${{ inputs.charm-path }}

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -70,7 +70,8 @@ jobs:
           cd ${{ inputs.charm-path }}
           if [ -f tox.ini ]; then
             tox -vve integration
-          else  
+          else
+            sudo snap install --classic astral-uv
             make unit
           fi
       - name: Dump logs

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -72,7 +72,7 @@ jobs:
             tox -vve integration
           else
             sudo snap install --classic astral-uv
-            make unit
+            make integration
           fi
       - name: Dump logs
         if: failure()

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -65,15 +65,13 @@ jobs:
           microk8s-group: snap_microk8s
           microk8s-addons: "hostpath-storage dns metallb:${{ inputs.ip-range || steps.ip_range.outputs.ip_range }}"
           charmcraft-channel: "${{ inputs.charmcraft-channel }}"
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic astral-uv
       - name: Run integration tests
         run: |
           cd ${{ inputs.charm-path }}
-          if [ -f tox.ini ]; then
-            tox -vve integration
-          else
-            sudo snap install --classic astral-uv
-            make integration
-          fi
+          [ -f tox.ini ] && tox -vve integration || make integration
       - name: Dump logs
         if: failure()
         uses: canonical/charming-actions/dump-logs@main

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -31,7 +31,7 @@ defaults:
 jobs:
   integration-test:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install --classic astral-uv
-          sudo apt-get install -y just
+          sudo apt install -y just
       - name: Run integration tests
         run: |
           cd ${{ inputs.charm-path }}

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install tox
           sudo snap install --classic astral-uv
-          sudo apt install just
+          sudo apt-get install -y just
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -23,7 +23,6 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests
-        run: cd ${{ inputs.charm-path }}
         run: |
           cd ${{ inputs.charm-path }}
           if [ -f tox.ini ]; then

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   unit-tests:
     name: Scenario tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install tox
           sudo snap install --classic astral-uv
-          sudo apt-get install -y just
+          sudo apt install -y just
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests
-        run: cd ${{ inputs.charm-path }} && 
+        run: cd ${{ inputs.charm-path }}
         run: |
           cd ${{ inputs.charm-path }}
           if [ -f tox.ini ]; then

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -28,4 +28,4 @@ jobs:
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -e scenario || just scenario
+          [ -f tox.ini ] && tox -e scenario || just scenario || echo "Skipping scenario..."

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -23,4 +23,12 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests
-        run: cd ${{ inputs.charm-path }} && tox -e scenario
+        run: cd ${{ inputs.charm-path }} && 
+        run: |
+          cd ${{ inputs.charm-path }}
+          if [ -f tox.ini ]; then
+            tox -e scenario
+          else
+            sudo snap install --classic astral-uv
+            make scenario
+          fi

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -24,7 +24,8 @@ jobs:
         run: |
           python -m pip install tox
           sudo snap install --classic astral-uv
+          sudo apt install just
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -e scenario || make scenario
+          [ -f tox.ini ] && tox -e scenario || just scenario

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -21,13 +21,10 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: python -m pip install tox
+        run: |
+          python -m pip install tox
+          sudo snap install --classic astral-uv
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}
-          if [ -f tox.ini ]; then
-            tox -e scenario
-          else
-            sudo snap install --classic astral-uv
-            make scenario
-          fi
+          [ -f tox.ini ] && tox -e scenario || make scenario

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install tox
           sudo snap install --classic astral-uv
-          sudo apt install just
+          sudo apt-get install -y just
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install tox
           sudo snap install --classic astral-uv
-          sudo apt-get install -y just
+          sudo apt install -y just
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -21,13 +21,10 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: python -m pip install tox
+        run: |
+          python -m pip install tox
+          sudo snap install --classic astral-uv
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}
-          if [ -f tox.ini ]; then
-            tox -e unit
-          else
-            sudo snap install --classic astral-uv
-            make unit
-          fi
+          [ -f tox.ini ] && tox -e unit || make unit

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -24,7 +24,8 @@ jobs:
         run: |
           python -m pip install tox
           sudo snap install --classic astral-uv
+          sudo apt install just
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -e unit || make unit
+          [ -f tox.ini ] && tox -e unit || just unit

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -23,4 +23,10 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests
-        run: cd ${{ inputs.charm-path }} && tox -e unit
+        run: |
+          cd ${{ inputs.charm-path }}
+          if [ -f tox.ini ]; then
+            tox -e unit
+          else  
+            make unit
+          fi

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -27,6 +27,7 @@ jobs:
           cd ${{ inputs.charm-path }}
           if [ -f tox.ini ]; then
             tox -e unit
-          else  
+          else
+            sudo snap install --classic astral-uv
             make unit
           fi

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -68,7 +68,7 @@ jobs:
     needs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
-    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@feature/uv-ci-make
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@feature/uv-ci-just
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -68,7 +68,7 @@ jobs:
     needs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
-    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@main
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@feature/uv-ci-make
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}


### PR DESCRIPTION
Alternative to:
- https://github.com/canonical/observability/pull/229

Uses Just instead of Make.

Tandem PR:
- https://github.com/canonical/mimir-coordinator-k8s-operator/pull/92

Limitations vs. Make
1. Starting 24.04 just is an apt package (you can always pipx install just)
2. Some of our charms run earlier versions than 24.04 and there we cannot install just via apt in the charmcraft.yaml
3. There is no snap we maintain