### PR TITLE
Revert "Conditional uv vs. tox tests for quality-checks.yaml"

### DIFF
--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -21,10 +21,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: |
-          python3 -m pip install tox
-          sudo snap install --classic astral-uv
+        run: python3 -m pip install tox
       - name: Run linters
-        run: |
-          cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve lint || make lint
+        run: cd ${{ inputs.charm-path }} && tox -vve lint

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -21,13 +21,9 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: |
-          python3 -m pip install tox
-          sudo snap install --classic astral-uv
+        run: python3 -m pip install tox
       - name: Run static analysis for /lib for 3.8
-        run: |
-          cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve static-lib || make static
+        run: cd ${{ inputs.charm-path }} && tox -vve static-lib
   static-charm:
     name: Static Analysis of Charm
     runs-on: ubuntu-latest
@@ -41,10 +37,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: |
-          python3 -m pip install tox
-          sudo snap install --classic astral-uv
+        run: python3 -m pip install tox
       - name: Run static analysis (charm)
-        run: |
-          cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve static-charm || make static
+        run: cd ${{ inputs.charm-path }} && tox -vve static-charm

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -65,13 +65,8 @@ jobs:
           microk8s-group: snap_microk8s
           microk8s-addons: "hostpath-storage dns metallb:${{ inputs.ip-range || steps.ip_range.outputs.ip_range }}"
           charmcraft-channel: "${{ inputs.charmcraft-channel }}"
-      - name: Install dependencies
-        run: |
-          sudo snap install --classic astral-uv
       - name: Run integration tests
-        run: |
-          cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve integration || make integration
+        run: cd ${{ inputs.charm-path }} && tox -vve integration
       - name: Dump logs
         if: failure()
         uses: canonical/charming-actions/dump-logs@main

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -21,10 +21,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: |
-          python -m pip install tox
-          sudo snap install --classic astral-uv
+        run: python -m pip install tox
       - name: Run tests
-        run: |
-          cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -e scenario || make scenario || echo "Skipping scenario..."
+        run: cd ${{ inputs.charm-path }} && tox -e scenario

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -21,10 +21,6 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: |
-          python -m pip install tox
-          sudo snap install --classic astral-uv
+        run: python -m pip install tox
       - name: Run tests
-        run: |
-          cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -e unit || make unit
+        run: cd ${{ inputs.charm-path }} && tox -e unit


### PR DESCRIPTION
Solves https://github.com/canonical/observability/issues/249

This reverts commit 8d3b5c160bd7184c21d17bfb2bf89371d3be5083.
And changes for:
- https://github.com/canonical/observability/pull/229

This is causing false negatives in CI and we are also not going with the Make approach anymore except for in Mimir:
- https://github.com/canonical/mimir-coordinator-k8s-operator
- https://github.com/canonical/mimir-worker-k8s-operator