### PR TITLE
Add conditional logic to allow CI and Make

### DIFF
--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -27,4 +27,8 @@ jobs:
       - name: Run linters
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve lint || make lint
+          if [ -f tox.ini ]; then
+              tox -vve lint
+          else
+              make lint
+          fi

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -27,7 +27,11 @@ jobs:
       - name: Run static analysis for /lib for 3.8
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve static-lib || make static
+          if [ -f tox.ini ]; then
+              tox -vve static-lib
+          else
+              make static
+          fi
   static-charm:
     name: Static Analysis of Charm
     runs-on: ubuntu-latest
@@ -47,4 +51,8 @@ jobs:
       - name: Run static analysis (charm)
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve static-charm || make static
+          if [ -f tox.ini ]; then
+              tox -vve static-charm
+          else
+              make static
+          fi

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -71,7 +71,11 @@ jobs:
       - name: Run integration tests
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -vve integration || make integration
+          if [ -f tox.ini ]; then
+              tox -vve integration
+          else
+              make integration
+          fi
       - name: Dump logs
         if: failure()
         uses: canonical/charming-actions/dump-logs@main

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -27,4 +27,8 @@ jobs:
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -e scenario || make scenario || echo "Skipping scenario..."
+          if [ -f tox.ini ]; then
+              tox -e scenario
+          else
+              make scenario
+          fi

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -27,4 +27,8 @@ jobs:
       - name: Run tests
         run: |
           cd ${{ inputs.charm-path }}
-          [ -f tox.ini ] && tox -e unit || make unit
+          if [ -f tox.ini ]; then
+              tox -e unit
+          else
+              make unit
+          fi


### PR DESCRIPTION
Fixes #249

This conditional logic ensures that we do not run Make if the test has failures. This also assumes that the whole test suite is ran for each repo even if there are no (e.g. scenario) tests which exist.

This would require repos that have Make, have each test type with a valid recipe. For example, if a repo does not have Scenario tests, the Make recipe would be:

```
scenario:
	echo "no scenario tests for this repo"
```