### PR TITLE
Add `catalogue` + `ingress` tempo integrations in COS TF module

### DIFF
--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -40,8 +40,7 @@ module "ssc" {
 }
 
 module "tempo" {
-  # TODO: remove ref before merging
-  source                  = "git::https://github.com/canonical/observability//terraform/modules/tempo?ref=TAP-158"
+  source                  = "git::https://github.com/canonical/observability//terraform/modules/tempo"
   model_name              = var.model_name
   channel                 = var.channel
   compactor_units         = var.tempo_compactor_units

--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -288,6 +288,20 @@ resource "juju_integration" "grafana_catalogue" {
   }
 }
 
+resource "juju_integration" "tempo_catalogue" {
+  model = var.model_name
+
+  application {
+    name     = module.catalogue.app_name
+    endpoint = module.catalogue.endpoints.catalogue
+  }
+
+  application {
+    name     = module.tempo.app_names.tempo_coordinator
+    endpoint = module.tempo.endpoints.catalogue
+  }
+}
+
 # Provided by Traefik
 
 resource "juju_integration" "catalogue_ingress" {
@@ -329,6 +343,20 @@ resource "juju_integration" "loki_ingress" {
   application {
     name     = module.loki.app_names.loki_coordinator
     endpoint = module.loki.endpoints.ingress
+  }
+}
+
+resource "juju_integration" "tempo_ingress" {
+  model = var.model_name
+
+  application {
+    name     = module.traefik.app_name
+    endpoint = module.traefik.endpoints.traefik_route
+  }
+
+  application {
+    name     = module.tempo.app_names.tempo_coordinator
+    endpoint = module.tempo.endpoints.ingress
   }
 }
 

--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -40,7 +40,8 @@ module "ssc" {
 }
 
 module "tempo" {
-  source                  = "git::https://github.com/canonical/observability//terraform/modules/tempo"
+  # TODO: remove ref before merging
+  source                  = "git::https://github.com/canonical/observability//terraform/modules/tempo?ref=TAP-158"
   model_name              = var.model_name
   channel                 = var.channel
   compactor_units         = var.tempo_compactor_units

--- a/terraform/modules/tempo/main.tf
+++ b/terraform/modules/tempo/main.tf
@@ -1,5 +1,5 @@
 module "tempo_coordinator" {
-  source     = "git::https://github.com/canonical/tempo-coordinator-k8s-operator//terraform"
+  source     = "/home/michael/Work/tempo-coordinator-k8s-operator/terraform"
   model_name = var.model_name
   channel    = var.channel
 }

--- a/terraform/modules/tempo/main.tf
+++ b/terraform/modules/tempo/main.tf
@@ -1,5 +1,5 @@
 module "tempo_coordinator" {
-  source     = "/home/michael/Work/tempo-coordinator-k8s-operator/terraform"
+  source     = "git::https://github.com/canonical/tempo-coordinator-k8s-operator//terraform"
   model_name = var.model_name
   channel    = var.channel
 }

--- a/terraform/modules/tempo/outputs.tf
+++ b/terraform/modules/tempo/outputs.tf
@@ -16,10 +16,12 @@ output "app_names" {
 output "endpoints" {
   value = {
     # Requires
-    logging           = "logging",
-    ingress           = "ingress",
-    certificates      = "certificates",
-    send-remote-write = "send-remote-write",
+    logging            = "logging",
+    ingress            = "ingress",
+    certificates       = "certificates",
+    send-remote-write  = "send-remote-write",
+    receive_datasource = "receive-datasource"
+    catalogue          = "catalogue",
 
     # Provides
     tempo_cluster     = "tempo-cluster"


### PR DESCRIPTION
Contributes to fixing https://github.com/canonical/observability/issues/245
Adds:
- `tempo:ingress → traefik:traefik_route` relation
- `tempo:catalogue → catalogue` relation

## Context
TODO
- [x] merge https://github.com/canonical/tempo-coordinator-k8s-operator/pull/93

## Testing Considerations

Create a `main.tf` file with the following:


```hcl
# COS module that deploy the whole Canonical Observability Stack
module "cos" {
  source         = "git::https://github.com/canonical/observability//terraform/modules/cos?ref=TAP-158"
  model_name     = var.model_name
  minio_password = var.minio_password
  minio_user     = var.minio_user
}

# S3 module that deploy the Object Storage MinIO required by COS
module "minio" {
  source         = "git::https://github.com/canonical/observability//terraform/modules/minio"
  model_name     = var.model_name
  channel        = var.channel
  minio_user     = var.minio_user
  minio_password = var.minio_password

  loki  = module.cos.loki
  mimir = module.cos.mimir
  tempo = module.cos.tempo
}

variable "channel" {
  description = "Charms channel"
  type        = string
  default     = "latest/edge"
}

variable "model_name" {
  description = "Model name"
  type        = string
}
variable "minio_user" {
  description = "User for MinIO"
  type        = string
}

variable "minio_password" {
  description = "Password for MinIO"
  type        = string
  sensitive   = true
}
```

And then run:

```shell

terraform init 

terraform apply -var='minio_password=mysecretkey' -var='minio_user=myaccesskey' -var='model_name=test'
```
All units should be in `active/idle`
