### PR TITLE
Pin integration tests to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -31,6 +31,7 @@ defaults:
 jobs:
   integration-test:
     name: Integration Tests
+    # Pinned since multiple itests were failing when switching to 24.04 due to permissions
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -31,7 +31,7 @@ defaults:
 jobs:
   integration-test:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The GitHub CI `ubuntu-latest` now points to `24.04` and is causing some errors in itests for [prometheus](https://github.com/canonical/prometheus-k8s-operator/actions/runs/12672194323/job/35315754969?pr=660#step:8:673) and [grafana-agent](https://github.com/canonical/grafana-agent-operator/actions/runs/12674074506/job/35321970421?pr=228#step:8:573). Pinning to `ubuntu-22.04` to solve temporarily.