### PR TITLE
feat(ci): Add grafana-cloud-integrator to promote train

### DIFF
--- a/.github/workflows/_local-promote-train.yaml
+++ b/.github/workflows/_local-promote-train.yaml
@@ -24,6 +24,7 @@ jobs:
           - cos-proxy-operator
           - grafana-agent-k8s-operator
           - grafana-agent-operator
+          - grafana-cloud-integrator
           - grafana-k8s-operator
           - istio-beacon-k8s-operator
           - istio-ingress-k8s-operator


### PR DESCRIPTION
Looks like it was missed back when it was created, so we don't have a `stable` revision for 22.04 base.