### PR TITLE
Replace MinIO with S3 Integrator

### DIFF
--- a/terraform/modules/cos/README.md
+++ b/terraform/modules/cos/README.md
@@ -1,6 +1,6 @@
-Terraform module for COS HA solution
+Terraform module for COS solution
 
-This is a Terraform module facilitating the deployment of COS HA solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+This is a Terraform module facilitating the deployment of COS solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
 The HA solution consists of the following Terraform modules:
 - [grafana-k8s](https://github.com/canonical/grafana-k8s-operator): Visualization, monitoring, and dashboards.
@@ -27,8 +27,6 @@ The module offers the following configurable inputs:
 | `channel` | string | Channel that the charms are deployed from | latest/edge |
 | `model_name` | string | Name of the model that the charm is deployed on |  |
 | `use_tls` | bool | Specify whether to use TLS or not for coordinator-worker communication |
-| `minio_user` | string | User for MinIO |
-| `minio_password` | string | Password for MinIO |
 | `loki_backend_units` | number | Number of Loki worker units with backend role |
 | `loki_backend_units` | number | Number of Loki worker units with backend role |
 | `loki_read_units` | number | Number of Loki worker units with read role |
@@ -42,6 +40,13 @@ The module offers the following configurable inputs:
 | `tempo_metrics_generator_units` | number | Number of Tempo worker units with metrics_generator role |
 | `tempo_querier_units` | number | Number of Tempo worker units with querier role |
 | `tempo_query_frontend_units` | number | Number of Tempo worker units with query_frontend role |
+| `s3_user` | string | User to connect to the S3 provider | 1 |
+| `s3_password` | string | Password to connect to the S3 provider | 1 |
+| `s3_endpoint` | string | Endpoint of the S3 provider | 1 |
+| `loki_bucket` | string | Name of the bucke in which Loki stores logs | 1 |
+| `mimir_bucket` | string | Name of the bucke in which Mimir stores metrics | 1 |
+| `tempo_bucket` | string | Name of the bucke in which Tempo stores traces | 1 |
+
 
 
 
@@ -80,23 +85,28 @@ In orrder to deploy COS with just one unit per worker charm create a `main.rf` f
 ```hcl
 # COS module that deploy the whole Canonical Observability Stack
 module "cos" {
-  source         = "git::https://github.com/canonical/observability//terraform/modules/cos"
-  model_name     = var.model_name
-  minio_password = var.minio_password
-  minio_user     = var.minio_user
-}
+  source       = "git::https://github.com/canonical/observability//terraform/modules/cos"
+  model_name   = var.model_name
+  channel      = var.channel
+  s3_endpoint  = var.s3_endpoint
+  s3_password  = var.s3_password
+  s3_user      = var.s3_user
+  loki_bucket  = var.loki_bucket
+  mimir_bucket = var.mimir_bucket
+  tempo_bucket = var.tempo_bucket
 
-# S3 module that deploy the Object Storage MinIO required by COS
-module "minio" {
-  source         = "git::https://github.com/canonical/observability//terraform/modules/minio"
-  model_name     = var.model_name
-  channel        = var.channel
-  minio_user     = var.minio_user
-  minio_password = var.minio_password
-
-  loki  = module.cos.loki
-  mimir = module.cos.mimir
-  tempo = module.cos.tempo
+  loki_backend_units            = var.loki_backend_units
+  loki_read_units               = var.loki_read_units
+  loki_write_units              = var.loki_write_units
+  mimir_backend_units           = var.mimir_backend_units
+  mimir_read_units              = var.mimir_read_units
+  mimir_write_units             = var.mimir_write_units
+  tempo_compactor_units         = var.tempo_compactor_units
+  tempo_distributor_units       = var.tempo_distributor_units
+  tempo_ingester_units          = var.tempo_ingester_units
+  tempo_metrics_generator_units = var.tempo_metrics_generator_units
+  tempo_querier_units           = var.tempo_querier_units
+  tempo_query_frontend_units    = var.tempo_query_frontend_units
 }
 
 variable "channel" {
@@ -109,23 +119,272 @@ variable "model_name" {
   description = "Model name"
   type        = string
 }
-variable "minio_user" {
-  description = "User for MinIO"
+
+variable "use_tls" {
+  description = "Specify whether to use TLS or not for coordinator-worker communication. By default, TLS is enabled through self-signed-certificates"
+  type        = bool
+  default     = true
+}
+
+variable "s3_endpoint" {
+  description = "S3 endpoint"
   type        = string
 }
 
-variable "minio_password" {
-  description = "Password for MinIO"
+variable "s3_user" {
+  description = "S3 user"
   type        = string
   sensitive   = true
 }
+
+variable "s3_password" {
+  description = "S3 password"
+  type        = string
+  sensitive   = true
+}
+
+variable "loki_bucket" {
+  description = "Loki bucket name"
+  type        = string
+  sensitive   = true
+}
+
+variable "mimir_bucket" {
+  description = "Mimir bucket name"
+  type        = string
+  sensitive   = true
+}
+
+variable "tempo_bucket" {
+  description = "Tempo bucket name"
+  type        = string
+  sensitive   = true
+}
+
+variable "loki_backend_units" {
+  description = "Number of Loki worker units with backend role"
+  type        = number
+  default     = 1
+}
+
+variable "loki_read_units" {
+  description = "Number of Loki worker units with read role"
+  type        = number
+  default     = 1
+}
+
+variable "loki_write_units" {
+  description = "Number of Loki worker units with write roles"
+  type        = number
+  default     = 1
+}
+
+variable "mimir_backend_units" {
+  description = "Number of Mimir worker units with backend role"
+  type        = number
+  default     = 1
+}
+
+variable "mimir_read_units" {
+  description = "Number of Mimir worker units with read role"
+  type        = number
+  default     = 1
+}
+
+variable "mimir_write_units" {
+  description = "Number of Mimir worker units with write role"
+  type        = number
+  default     = 1
+}
+
+variable "tempo_compactor_units" {
+  description = "Number of Tempo worker units with compactor role"
+  type        = number
+  default     = 1
+}
+
+variable "tempo_distributor_units" {
+  description = "Number of Tempo worker units with distributor role"
+  type        = number
+  default     = 1
+}
+
+variable "tempo_ingester_units" {
+  description = "Number of Tempo worker units with ingester role"
+  type        = number
+  default     = 1
+}
+
+variable "tempo_metrics_generator_units" {
+  description = "Number of Tempo worker units with metrics-generator role"
+  type        = number
+  default     = 1
+}
+
+variable "tempo_querier_units" {
+  description = "Number of Tempo worker units with querier role"
+  type        = number
+  default     = 1
+}
+variable "tempo_query_frontend_units" {
+  description = "Number of Tempo worker units with query-frontend role"
+  type        = number
+  default     = 1
+}
 ```
 
-
-Then execute:
+Then, use terraform to deploy the module, using 3 units per worker:
 
 ```shell
-$ tofu init
+terraform init
 
-$ tofu apply -var='minio_password=Password' -var='minio_user=User' -var='model_name=test'
+terraform apply -var='s3_password=bar' -var='s3_user=foo' -var='s3_endpoint=http://192.168.1.145' \
+-var='loki_bucket=loki' -var='model_name=cos' -var='mimir_bucket=mimir' -var='tempo_bucket=tempo' \
+-var='loki_backend_units=3' -var='loki_read_units=3' -var='loki_write_units=3' \
+-var='mimir_backend_units=3' -var='mimir_read_units=3' -var='mimir_write_units=3' \
+-var='tempo_compactor_units=3' -var='tempo_distributor_units=3' -var='tempo_ingester_units=3' \
+-var='tempo_metrics_generator_units=3' -var='tempo_querier_units=3' -var='tempo_query_frontend_units=3'
+```
+
+Some minutes after running these two commands, we have a distributed COS deployment!
+
+```shell
+$ juju status --relations
+Model  Controller  Cloud/Region        Version  SLA          Timestamp
+cos    microk8s    microk8s/localhost  3.6.2    unsupported  20:16:42-03:00
+
+App                       Version  Status  Scale  Charm                     Channel      Rev  Address         Exposed  Message
+alertmanager              0.27.0   active      1  alertmanager-k8s          latest/edge  156  10.152.183.57   no
+catalogue                          active      1  catalogue-k8s             latest/edge   81  10.152.183.88   no
+grafana                   9.5.3    active      1  grafana-k8s               latest/edge  141  10.152.183.138  no
+grafana-agent             0.40.4   active      1  grafana-agent-k8s         latest/edge  112  10.152.183.37   no       grafana-dashboards-provider: off
+loki                               active      1  loki-coordinator-k8s      latest/edge   20  10.152.183.201  no
+loki-backend              3.0.0    active      3  loki-worker-k8s           latest/edge   34  10.152.183.112  no       backend ready.
+loki-read                 3.0.0    active      3  loki-worker-k8s           latest/edge   34  10.152.183.87   no       read ready.
+loki-s3-integrator                 active      1  s3-integrator             latest/edge  139  10.152.183.20   no
+loki-write                3.0.0    active      3  loki-worker-k8s           latest/edge   34  10.152.183.167  no       write ready.
+mimir                              active      1  mimir-coordinator-k8s     latest/edge   38  10.152.183.207  no
+mimir-backend             2.13.0   active      3  mimir-worker-k8s          latest/edge   45  10.152.183.45   no       backend ready.
+mimir-read                2.13.0   active      3  mimir-worker-k8s          latest/edge   45  10.152.183.160  no       read ready.
+mimir-s3-integrator                active      1  s3-integrator             latest/edge  139  10.152.183.85   no
+mimir-write               2.13.0   active      3  mimir-worker-k8s          latest/edge   45  10.152.183.125  no       write ready.
+self-signed-certificates           active      1  self-signed-certificates  1/edge       268  10.152.183.34   no
+tempo                              active      1  tempo-coordinator-k8s     latest/edge   70  10.152.183.72   no
+tempo-compactor           2.7.1    active      3  tempo-worker-k8s          latest/edge   52  10.152.183.99   no       compactor ready.
+tempo-distributor         2.7.1    active      3  tempo-worker-k8s          latest/edge   52  10.152.183.162  no       distributor ready.
+tempo-ingester            2.7.1    active      3  tempo-worker-k8s          latest/edge   52  10.152.183.195  no       ingester ready.
+tempo-metrics-generator   2.7.1    active      3  tempo-worker-k8s          latest/edge   52  10.152.183.122  no       metrics-generator ready.
+tempo-querier             2.7.1    active      3  tempo-worker-k8s          latest/edge   52  10.152.183.136  no       querier ready.
+tempo-query-frontend      2.7.1    active      3  tempo-worker-k8s          latest/edge   52  10.152.183.105  no       query-frontend ready.
+tempo-s3-integrator                active      1  s3-integrator             latest/edge  139  10.152.183.121  no
+traefik                   2.11.0   active      1  traefik-k8s               latest/edge  234  10.152.183.110  no       Serving at 192.168.1.244
+
+Unit                         Workload  Agent  Address       Ports  Message
+alertmanager/0*              active    idle   10.1.167.134
+catalogue/0*                 active    idle   10.1.167.150
+grafana-agent/0*             active    idle   10.1.167.149         grafana-dashboards-provider: off
+grafana/0*                   active    idle   10.1.167.173
+loki-backend/0*              active    idle   10.1.167.148         backend ready.
+loki-backend/1               active    idle   10.1.167.171         backend ready.
+loki-backend/2               active    idle   10.1.167.188         backend ready.
+loki-read/0                  active    idle   10.1.167.153         read ready.
+loki-read/1                  active    idle   10.1.167.180         read ready.
+loki-read/2*                 active    idle   10.1.167.183         read ready.
+loki-s3-integrator/0*        active    idle   10.1.167.169
+loki-write/0*                active    idle   10.1.167.144         write ready.
+loki-write/1                 active    idle   10.1.167.142         write ready.
+loki-write/2                 active    idle   10.1.167.187         write ready.
+loki/0*                      active    idle   10.1.167.174
+mimir-backend/0*             active    idle   10.1.167.139         backend ready.
+mimir-backend/1              active    idle   10.1.167.128         backend ready.
+mimir-backend/2              active    idle   10.1.167.177         backend ready.
+mimir-read/0*                active    idle   10.1.167.151         read ready.
+mimir-read/1                 active    idle   10.1.167.163         read ready.
+mimir-read/2                 active    idle   10.1.167.132         read ready.
+mimir-s3-integrator/0*       active    idle   10.1.167.137
+mimir-write/0*               active    idle   10.1.167.152         write ready.
+mimir-write/1                active    idle   10.1.167.167         write ready.
+mimir-write/2                active    idle   10.1.167.143         write ready.
+mimir/0*                     active    idle   10.1.167.135
+self-signed-certificates/0*  active    idle   10.1.167.166
+tempo-compactor/0            active    idle   10.1.167.181         compactor ready.
+tempo-compactor/1*           active    idle   10.1.167.168         compactor ready.
+tempo-compactor/2            active    idle   10.1.167.129         compactor ready.
+tempo-distributor/0*         active    idle   10.1.167.157         distributor ready.
+tempo-distributor/1          active    idle   10.1.167.131         distributor ready.
+tempo-distributor/2          active    idle   10.1.167.186         distributor ready.
+tempo-ingester/0*            active    idle   10.1.167.191         ingester ready.
+tempo-ingester/1             active    idle   10.1.167.133         ingester ready.
+tempo-ingester/2             active    idle   10.1.167.179         ingester ready.
+tempo-metrics-generator/0*   active    idle   10.1.167.147         metrics-generator ready.
+tempo-metrics-generator/1    active    idle   10.1.167.159         metrics-generator ready.
+tempo-metrics-generator/2    active    idle   10.1.167.146         metrics-generator ready.
+tempo-querier/0              active    idle   10.1.167.170         querier ready.
+tempo-querier/1              active    idle   10.1.167.140         querier ready.
+tempo-querier/2*             active    idle   10.1.167.165         querier ready.
+tempo-query-frontend/0*      active    idle   10.1.167.162         query-frontend ready.
+tempo-query-frontend/1       active    idle   10.1.167.190         query-frontend ready.
+tempo-query-frontend/2       active    idle   10.1.167.184         query-frontend ready.
+tempo-s3-integrator/0*       active    idle   10.1.167.172
+tempo/0*                     active    idle   10.1.167.189
+traefik/0*                   active    idle   10.1.167.182         Serving at 192.168.1.244
+
+Integration provider                     Requirer                                 Interface                Type     Message
+alertmanager:alerting                    loki:alertmanager                        alertmanager_dispatch    regular
+alertmanager:alerting                    mimir:alertmanager                       alertmanager_dispatch    regular
+alertmanager:grafana-dashboard           grafana:grafana-dashboard                grafana_dashboard        regular
+alertmanager:grafana-source              grafana:grafana-source                   grafana_datasource       regular
+alertmanager:replicas                    alertmanager:replicas                    alertmanager_replica     peer
+alertmanager:self-metrics-endpoint       grafana-agent:metrics-endpoint           prometheus_scrape        regular
+catalogue:catalogue                      alertmanager:catalogue                   catalogue                regular
+catalogue:catalogue                      grafana:catalogue                        catalogue                regular
+catalogue:catalogue                      mimir:catalogue                          catalogue                regular
+catalogue:catalogue                      tempo:catalogue                          catalogue                regular
+catalogue:replicas                       catalogue:replicas                       catalogue_replica        peer
+grafana-agent:logging-provider           loki:logging-consumer                    loki_push_api            regular
+grafana-agent:logging-provider           tempo:logging                            loki_push_api            regular
+grafana-agent:peers                      grafana-agent:peers                      grafana_agent_replica    peer
+grafana-agent:tracing-provider           grafana:charm-tracing                    tracing                  regular
+grafana-agent:tracing-provider           loki:charm-tracing                       tracing                  regular
+grafana-agent:tracing-provider           mimir:charm-tracing                      tracing                  regular
+grafana:grafana                          grafana:grafana                          grafana_peers            peer
+grafana:replicas                         grafana:replicas                         grafana_replicas         peer
+loki-s3-integrator:s3-credentials        loki:s3                                  s3                       regular
+loki-s3-integrator:s3-integrator-peers   loki-s3-integrator:s3-integrator-peers   s3-integrator-peers      peer
+loki:grafana-dashboards-provider         grafana:grafana-dashboard                grafana_dashboard        regular
+loki:grafana-source                      grafana:grafana-source                   grafana_datasource       regular
+loki:logging                             grafana-agent:logging-consumer           loki_push_api            regular
+loki:loki-cluster                        loki-backend:loki-cluster                loki_cluster             regular
+loki:loki-cluster                        loki-read:loki-cluster                   loki_cluster             regular
+loki:loki-cluster                        loki-write:loki-cluster                  loki_cluster             regular
+loki:self-metrics-endpoint               grafana-agent:metrics-endpoint           prometheus_scrape        regular
+mimir-s3-integrator:s3-credentials       mimir:s3                                 s3                       regular
+mimir-s3-integrator:s3-integrator-peers  mimir-s3-integrator:s3-integrator-peers  s3-integrator-peers      peer
+mimir:grafana-dashboards-provider        grafana:grafana-dashboard                grafana_dashboard        regular
+mimir:grafana-source                     grafana:grafana-source                   grafana_datasource       regular
+mimir:mimir-cluster                      mimir-backend:mimir-cluster              mimir_cluster            regular
+mimir:mimir-cluster                      mimir-read:mimir-cluster                 mimir_cluster            regular
+mimir:mimir-cluster                      mimir-write:mimir-cluster                mimir_cluster            regular
+mimir:receive-remote-write               grafana-agent:send-remote-write          prometheus_remote_write  regular
+mimir:receive-remote-write               tempo:send-remote-write                  prometheus_remote_write  regular
+mimir:self-metrics-endpoint              grafana-agent:metrics-endpoint           prometheus_scrape        regular
+tempo-s3-integrator:s3-credentials       tempo:s3                                 s3                       regular
+tempo-s3-integrator:s3-integrator-peers  tempo-s3-integrator:s3-integrator-peers  s3-integrator-peers      peer
+tempo:grafana-source                     grafana:grafana-source                   grafana_datasource       regular
+tempo:metrics-endpoint                   grafana-agent:metrics-endpoint           prometheus_scrape        regular
+tempo:peers                              tempo:peers                              tempo_peers              peer
+tempo:tempo-cluster                      tempo-compactor:tempo-cluster            tempo_cluster            regular
+tempo:tempo-cluster                      tempo-distributor:tempo-cluster          tempo_cluster            regular
+tempo:tempo-cluster                      tempo-ingester:tempo-cluster             tempo_cluster            regular
+tempo:tempo-cluster                      tempo-metrics-generator:tempo-cluster    tempo_cluster            regular
+tempo:tempo-cluster                      tempo-querier:tempo-cluster              tempo_cluster            regular
+tempo:tempo-cluster                      tempo-query-frontend:tempo-cluster       tempo_cluster            regular
+tempo:tracing                            grafana-agent:tracing                    tracing                  regular
+traefik:ingress                          alertmanager:ingress                     ingress                  regular
+traefik:ingress                          catalogue:ingress                        ingress                  regular
+traefik:ingress                          loki:ingress                             ingress                  regular
+traefik:ingress                          mimir:ingress                            ingress                  regular
+traefik:peers                            traefik:peers                            traefik_peers            peer
+traefik:traefik-route                    grafana:ingress                          traefik_route            regular
+traefik:traefik-route                    tempo:ingress                            traefik_route            regular
 ```

--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -22,8 +22,7 @@ module "grafana" {
 }
 
 module "loki" {
-  # source        = "git::https://github.com/canonical/observability//terraform/modules/loki"
-  source        = "../loki"
+  source        = "git::https://github.com/canonical/observability//terraform/modules/loki"
   model_name    = var.model_name
   channel       = var.channel
   backend_units = var.loki_backend_units
@@ -36,8 +35,7 @@ module "loki" {
 }
 
 module "mimir" {
-  # source        = "git::https://github.com/canonical/observability//terraform/modules/mimir"
-  source        = "../mimir"
+  source        = "git::https://github.com/canonical/observability//terraform/modules/mimir"
   model_name    = var.model_name
   channel       = var.channel
   backend_units = var.mimir_backend_units
@@ -57,8 +55,7 @@ module "ssc" {
 }
 
 module "tempo" {
-  # source                  = "git::https://github.com/canonical/observability//terraform/modules/tempo"
-  source                  = "../tempo"
+  source                  = "git::https://github.com/canonical/observability//terraform/modules/tempo"
   model_name              = var.model_name
   channel                 = var.channel
   compactor_units         = var.tempo_compactor_units

--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -28,7 +28,7 @@ module "loki" {
   backend_units = var.loki_backend_units
   read_units    = var.loki_read_units
   write_units   = var.loki_write_units
-  loki_bucket   = var.loki_bucket
+  s3_bucket     = var.loki_bucket
   s3_endpoint   = var.s3_endpoint
   s3_password   = var.s3_password
   s3_user       = var.s3_user
@@ -41,7 +41,7 @@ module "mimir" {
   backend_units = var.mimir_backend_units
   read_units    = var.mimir_read_units
   write_units   = var.mimir_write_units
-  mimir_bucket  = var.mimir_bucket
+  s3_bucket     = var.mimir_bucket
   s3_endpoint   = var.s3_endpoint
   s3_password   = var.s3_password
   s3_user       = var.s3_user
@@ -64,7 +64,7 @@ module "tempo" {
   metrics_generator_units = var.tempo_metrics_generator_units
   querier_units           = var.tempo_querier_units
   query_frontend_units    = var.tempo_query_frontend_units
-  tempo_bucket            = var.tempo_bucket
+  s3_bucket               = var.tempo_bucket
   s3_endpoint             = var.s3_endpoint
   s3_password             = var.s3_password
   s3_user                 = var.s3_user

--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -22,21 +22,31 @@ module "grafana" {
 }
 
 module "loki" {
-  source        = "git::https://github.com/canonical/observability//terraform/modules/loki"
+  # source        = "git::https://github.com/canonical/observability//terraform/modules/loki"
+  source        = "../loki"
   model_name    = var.model_name
   channel       = var.channel
   backend_units = var.loki_backend_units
   read_units    = var.loki_read_units
   write_units   = var.loki_write_units
+  loki_bucket   = var.loki_bucket
+  s3_endpoint   = var.s3_endpoint
+  s3_password   = var.s3_password
+  s3_user       = var.s3_user
 }
 
 module "mimir" {
-  source        = "git::https://github.com/canonical/observability//terraform/modules/mimir"
+  # source        = "git::https://github.com/canonical/observability//terraform/modules/mimir"
+  source        = "../mimir"
   model_name    = var.model_name
   channel       = var.channel
   backend_units = var.mimir_backend_units
   read_units    = var.mimir_read_units
   write_units   = var.mimir_write_units
+  mimir_bucket  = var.mimir_bucket
+  s3_endpoint   = var.s3_endpoint
+  s3_password   = var.s3_password
+  s3_user       = var.s3_user
 }
 
 module "ssc" {
@@ -47,7 +57,8 @@ module "ssc" {
 }
 
 module "tempo" {
-  source                  = "git::https://github.com/canonical/observability//terraform/modules/tempo"
+  # source                  = "git::https://github.com/canonical/observability//terraform/modules/tempo"
+  source                  = "../tempo"
   model_name              = var.model_name
   channel                 = var.channel
   compactor_units         = var.tempo_compactor_units
@@ -56,6 +67,10 @@ module "tempo" {
   metrics_generator_units = var.tempo_metrics_generator_units
   querier_units           = var.tempo_querier_units
   query_frontend_units    = var.tempo_query_frontend_units
+  tempo_bucket            = var.tempo_bucket
+  s3_endpoint             = var.s3_endpoint
+  s3_password             = var.s3_password
+  s3_user                 = var.s3_user
 }
 
 module "traefik" {

--- a/terraform/modules/cos/variables.tf
+++ b/terraform/modules/cos/variables.tf
@@ -15,13 +15,36 @@ variable "use_tls" {
   default     = true
 }
 
-variable "minio_user" {
-  description = "User for MinIO"
+variable "s3_endpoint" {
+  description = "S3 endpoint"
   type        = string
 }
 
-variable "minio_password" {
-  description = "Password for MinIO"
+variable "s3_user" {
+  description = "User for S3"
+  type        = string
+}
+
+variable "s3_password" {
+  description = "Password for S3"
+  type        = string
+  sensitive   = true
+}
+
+variable "loki_bucket" {
+  description = "Loki bucket name"
+  type        = string
+  sensitive   = true
+}
+
+variable "mimir_bucket" {
+  description = "Mimir bucket name"
+  type        = string
+  sensitive   = true
+}
+
+variable "tempo_bucket" {
+  description = "Tempo bucket name"
   type        = string
   sensitive   = true
 }

--- a/terraform/modules/loki/README.md
+++ b/terraform/modules/loki/README.md
@@ -1,8 +1,8 @@
-Terraform module for Loki HA solution
+Terraform module for Loki solution
 
-This is a Terraform module facilitating the deployment of Loki HA solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+This is a Terraform module facilitating the deployment of Loki solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
-The HA solution consists of the following Terraform modules:
+The solution consists of the following Terraform modules:
 - [loki-coordinator-k8s](https://github.com/canonical/loki-coordinator-k8s-operator): ingress, cluster coordination, single integration facade.
 - [loki-worker-k8s](https://github.com/canonical/loki-worker-k8s-operator): run one or more Loki application components.
 - [s3-integrator](https://github.com/canonical/s3-integrator): facade for S3 storage configurations.
@@ -11,7 +11,7 @@ The HA solution consists of the following Terraform modules:
 This Terraform module deploys Loki in its [microservices mode](https://grafana.com/docs/enterprise-logs/latest/get-started/deployment-modes/#microservices-mode), which runs each one of the required roles in distinct processes.
 
 
-> [!NOTE]  
+> [!NOTE]
 > `s3-integrator` itself doesn't act as an S3 object storage system. For the HA solution to be functional, `s3-integrator` needs to point to an S3-like storage. See [this guide](https://discourse.charmhub.io/t/cos-lite-docs-set-up-minio/15211) to learn how to connect to an S3-like storage for traces.
 
 ## Requirements
@@ -29,6 +29,11 @@ The module offers the following configurable inputs:
 | `model_name`| string | Name of the model that the charm is deployed on |  |
 | `read_units`| number | Number of Loki worker units with the read role | 1 |
 | `write_units`| number | Number of Loki worker units with the write role | 1 |
+| `s3_integrator_name` | string | Name of the s3-integrator app | 1 |
+| `s3_bucket` | string | Name of the bucke in which Loki stores logs | 1 |
+| `s3_user` | string | User to connect to the S3 provider | 1 |
+| `s3_password` | string | Password to connect to the S3 provider | 1 |
+| `s3_endpoint` | string | Endpoint of the S3 provider | 1 |
 
 ### Outputs
 Upon application, the module exports the following outputs:
@@ -48,7 +53,7 @@ Users should ensure that Terraform is aware of the `juju_model` dependency of th
 
 To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`. This would deploy all Loki HA solution modules in the same model.
 
-### High Availability 
+### Microservice deployment
 
 By default, this Terraform module will deploy each Loki worker with `1` unit. To configure the module to run `x` units of any worker role, you can run `terraform apply -var="model_name=<MODEL_NAME>" -var="<ROLE>_units=<x>" -auto-approve`.
 See [Loki worker roles](https://discourse.charmhub.io/t/loki-worker-roles/15484) for the recommended scale for each role.

--- a/terraform/modules/loki/main.tf
+++ b/terraform/modules/loki/main.tf
@@ -8,7 +8,30 @@ resource "juju_application" "s3_integrator" {
     name    = "s3-integrator"
     channel = var.channel
   }
+  config = {
+    endpoint = var.s3_endpoint
+    bucket   = var.loki_bucket
+  }
   units = 1
+}
+
+resource "terraform_data" "s3management" {
+  depends_on = [
+    juju_application.s3_integrator,
+  ]
+  input = {
+    S3_USER       = var.s3_user
+    S3_PASSWORD   = var.s3_password
+    MODEL_NAME    = var.model_name
+    S3_INTEGRATOR = var.s3_integrator_name
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      juju wait-for application -m "${self.input.MODEL_NAME}" "${self.input.S3_INTEGRATOR}" --query='forEach(units,  unit => unit.workload-status=="blocked" && unit.agent-status=="idle")' --timeout=30m
+      juju run -m "${self.input.MODEL_NAME}" "${self.input.S3_INTEGRATOR}/leader" sync-s3-credentials access-key="${self.input.S3_USER}" secret-key="${self.input.S3_PASSWORD}"
+    EOT
+  }
 }
 
 module "loki_coordinator" {

--- a/terraform/modules/loki/main.tf
+++ b/terraform/modules/loki/main.tf
@@ -10,7 +10,7 @@ resource "juju_application" "s3_integrator" {
   }
   config = {
     endpoint = var.s3_endpoint
-    bucket   = var.loki_bucket
+    bucket   = var.s3_bucket
   }
   units = 1
 }

--- a/terraform/modules/loki/outputs.tf
+++ b/terraform/modules/loki/outputs.tf
@@ -29,8 +29,8 @@ output "endpoints" {
   }
 }
 
-output "bucket_name" {
-  value       = var.bucket_name
+output "loki_bucket" {
+  value       = var.loki_bucket
   description = "The bucket name for Loki"
 }
 

--- a/terraform/modules/loki/outputs.tf
+++ b/terraform/modules/loki/outputs.tf
@@ -29,10 +29,6 @@ output "endpoints" {
   }
 }
 
-output "loki_bucket" {
-  value       = var.loki_bucket
-  description = "The bucket name for Loki"
-}
 
 output "s3_integrator_name" {
   value       = var.s3_integrator_name

--- a/terraform/modules/loki/variables.tf
+++ b/terraform/modules/loki/variables.tf
@@ -9,7 +9,7 @@ variable "model_name" {
   type        = string
 }
 
-variable "loki_bucket" {
+variable "s3_bucket" {
   description = "Bucket name"
   type        = string
   default     = "loki"

--- a/terraform/modules/loki/variables.tf
+++ b/terraform/modules/loki/variables.tf
@@ -9,10 +9,25 @@ variable "model_name" {
   type        = string
 }
 
-variable "bucket_name" {
+variable "loki_bucket" {
   description = "Bucket name"
   type        = string
   default     = "loki"
+}
+
+variable "s3_user" {
+  description = "S3 user"
+  type        = string
+}
+
+variable "s3_password" {
+  description = "S3 password"
+  type        = string
+}
+
+variable "s3_endpoint" {
+  description = "S3 endpoint"
+  type        = string
 }
 
 # -------------- # App Names --------------

--- a/terraform/modules/mimir/README.md
+++ b/terraform/modules/mimir/README.md
@@ -1,8 +1,8 @@
-Terraform module for Mimir HA solution
+Terraform module for Mimir solution
 
-This is a Terraform module facilitating the deployment of Mimir HA solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+This is a Terraform module facilitating the deployment of Mimir solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
-The HA solution consists of the following Terraform modules:
+The solution consists of the following Terraform modules:
 - [mimir-coordinator-k8s](https://github.com/canonical/mimir-coordinator-k8s-operator): ingress, cluster coordination, single integration facade.
 - [mimir-worker-k8s](https://github.com/canonical/mimir-worker-k8s-operator): run one or more mimir application components.
 - [s3-integrator](https://github.com/canonical/s3-integrator): facade for S3 storage configurations.
@@ -11,7 +11,7 @@ The HA solution consists of the following Terraform modules:
 This Terraform module deploys Mimir in its [microservices mode](https://grafana.com/docs/mimir/latest/references/architecture/deployment-modes/#microservices-mode), which runs each one of the required roles in distinct processes.
 
 
-> [!NOTE]  
+> [!NOTE]
 > `s3-integrator` itself doesn't act as an S3 object storage system. For the HA solution to be functional, `s3-integrator` needs to point to an S3-like storage. See [this guide](https://discourse.charmhub.io/t/cos-lite-docs-set-up-minio/15211) to learn how to connect to an S3-like storage for traces.
 
 ## Requirements
@@ -36,6 +36,12 @@ The module offers the following configurable inputs:
 | `query_scheduler_units`| number | Number of Mimir worker units with the query-scheduler role | 1 |
 | `ruler_units`| number | Number of Mimir worker units with the ruler role | 1 |
 | `store_gateway_units`| number | Number of Mimir worker units with the store-gateway role | 1 |
+| `s3_integrator_name` | string | Name of the s3-integrator app | 1 |
+| `s3_bucket` | string | Name of the bucke in which Mimir stores metrics | 1 |
+| `s3_user` | string | User to connect to the S3 provider | 1 |
+| `s3_password` | string | Password to connect to the S3 provider | 1 |
+| `s3_endpoint` | string | Endpoint of the S3 provider | 1 |
+
 
 ### Outputs
 Upon application, the module exports the following outputs:
@@ -55,7 +61,7 @@ Users should ensure that Terraform is aware of the `juju_model` dependency of th
 
 To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`. This would deploy all Mimir HA solution modules in the same model.
 
-### High Availability 
+### Microservice deployment
 
 By default, this Terraform module will deploy each Mimir worker with `1` unit. To configure the module to run `x` units of any worker role, you can run `terraform apply -var="model_name=<MODEL_NAME>" -var="<ROLE>_units=<x>" -auto-approve`.
 See [Mimir worker roles](https://discourse.charmhub.io/t/mimir-worker-roles/15484) for the recommended scale for each role.

--- a/terraform/modules/mimir/main.tf
+++ b/terraform/modules/mimir/main.tf
@@ -10,7 +10,7 @@ resource "juju_application" "s3_integrator" {
   }
   config = {
     endpoint = var.s3_endpoint
-    bucket   = var.mimir_bucket
+    bucket   = var.s3_bucket
   }
   units = 1
 

--- a/terraform/modules/mimir/main.tf
+++ b/terraform/modules/mimir/main.tf
@@ -8,8 +8,32 @@ resource "juju_application" "s3_integrator" {
     name    = "s3-integrator"
     channel = var.channel
   }
+  config = {
+    endpoint = var.s3_endpoint
+    bucket   = var.mimir_bucket
+  }
   units = 1
 
+}
+
+resource "terraform_data" "s3management" {
+  depends_on = [
+    juju_application.s3_integrator,
+  ]
+
+  input = {
+    S3_USER       = var.s3_user
+    S3_PASSWORD   = var.s3_password
+    MODEL_NAME    = var.model_name
+    S3_INTEGRATOR = var.s3_integrator_name
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      juju wait-for application -m "${self.input.MODEL_NAME}" "${self.input.S3_INTEGRATOR}" --query='forEach(units,  unit => unit.workload-status=="blocked" && unit.agent-status=="idle")' --timeout=30m
+      juju run -m "${self.input.MODEL_NAME}" "${self.input.S3_INTEGRATOR}/leader" sync-s3-credentials access-key="${self.input.S3_USER}" secret-key="${self.input.S3_PASSWORD}"
+    EOT
+  }
 }
 
 module "mimir_coordinator" {

--- a/terraform/modules/mimir/outputs.tf
+++ b/terraform/modules/mimir/outputs.tf
@@ -30,8 +30,8 @@ output "endpoints" {
   }
 }
 
-output "bucket_name" {
-  value       = var.bucket_name
+output "mimir_bucket" {
+  value       = var.mimir_bucket
   description = "The bucket name for Mimir"
 }
 

--- a/terraform/modules/mimir/outputs.tf
+++ b/terraform/modules/mimir/outputs.tf
@@ -30,11 +30,6 @@ output "endpoints" {
   }
 }
 
-output "mimir_bucket" {
-  value       = var.mimir_bucket
-  description = "The bucket name for Mimir"
-}
-
 output "s3_integrator_name" {
   value       = var.s3_integrator_name
   description = "Name of the s3-integrator for Mimir"

--- a/terraform/modules/mimir/variables.tf
+++ b/terraform/modules/mimir/variables.tf
@@ -9,10 +9,25 @@ variable "model_name" {
   type        = string
 }
 
-variable "bucket_name" {
-  description = "Model name"
+variable "mimir_bucket" {
+  description = "Bucket name"
   type        = string
   default     = "mimir"
+}
+
+variable "s3_user" {
+  description = "S3 user"
+  type        = string
+}
+
+variable "s3_password" {
+  description = "S3 password"
+  type        = string
+}
+
+variable "s3_endpoint" {
+  description = "S3 endpoint"
+  type        = string
 }
 
 # -------------- # App Names --------------

--- a/terraform/modules/mimir/variables.tf
+++ b/terraform/modules/mimir/variables.tf
@@ -9,7 +9,7 @@ variable "model_name" {
   type        = string
 }
 
-variable "mimir_bucket" {
+variable "s3_bucket" {
   description = "Bucket name"
   type        = string
   default     = "mimir"

--- a/terraform/modules/tempo/README.md
+++ b/terraform/modules/tempo/README.md
@@ -1,8 +1,8 @@
-Terraform module for Tempo HA solution
+Terraform module for Tempo solution
 
-This is a Terraform module facilitating the deployment of Tempo HA solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+This is a Terraform module facilitating the deployment of Tempo solution, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
-The HA solution consists of the following Terraform modules:
+The solution consists of the following Terraform modules:
 - [tempo-coordinator-k8s](https://github.com/canonical/tempo-coordinator-k8s-operator): ingress, cluster coordination, single integration facade.
 - [tempo-worker-k8s](https://github.com/canonical/tempo-worker-k8s-operator): run one or more tempo application components.
 - [s3-integrator](https://github.com/canonical/s3-integrator): facade for S3 storage configurations.
@@ -11,8 +11,8 @@ The HA solution consists of the following Terraform modules:
 This Terraform module deploys Tempo in its [microservices mode](https://grafana.com/docs/tempo/latest/setup/deployment/#microservices-mode), which runs each one of the required roles in distinct processes. [See](https://discourse.charmhub.io/t/topic/15484) to understand more about Tempo roles.
 
 
-> [!NOTE]  
-> `s3-integrator` itself doesn't act as an S3 object storage system. For the HA solution to be functional, `s3-integrator` needs to point to an S3-like storage. See [this guide](https://discourse.charmhub.io/t/cos-lite-docs-set-up-minio/15211) to learn how to connect to an S3-like storage for traces.
+> [!NOTE]
+> `s3-integrator` itself doesn't act as an S3 object storage system. For the solution to be functional, `s3-integrator` needs to point to an S3-like storage. See [this guide](https://discourse.charmhub.io/t/cos-lite-docs-set-up-minio/15211) to learn how to connect to an S3-like storage for traces.
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
@@ -32,6 +32,13 @@ The module offers the following configurable inputs:
 | `model_name`| string | Name of the model that the charm is deployed on |  |
 | `querier_units`| number | Number of Tempo worker units with querier role | 1 |
 | `query_frontend_units`| number | Number of Tempo worker units with query-frontend role | 1 |
+| `s3_integrator_name` | string | Name of the s3-integrator app | 1 |
+| `s3_bucket` | string | Name of the bucke in which Tempo stores traces | 1 |
+| `s3_user` | string | User to connect to the S3 provider | 1 |
+| `s3_password` | string | Password to connect to the S3 provider | 1 |
+| `s3_endpoint` | string | Endpoint of the S3 provider | 1 |
+
+
 
 ### Outputs
 Upon applied, the module exports the following outputs:
@@ -49,9 +56,9 @@ Upon applied, the module exports the following outputs:
 
 Users should ensure that Terraform is aware of the `juju_model` dependency of the charm module.
 
-To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`. This would deploy all Tempo HA solution modules in the same model.
+To deploy this module with its needed dependency, you can run `terraform apply -var="model_name=<MODEL_NAME>" -auto-approve`. This would deploy all Tempo components in the same model.
 
-### High Availability 
+### Microservice deployment
 
 By default, this Terraform module will deploy each Tempo worker with `1` unit. To configure the module to run `x` units of any worker role, you can run `terraform apply -var="model_name=<MODEL_NAME>" -var="<ROLE>_units=<x>" -auto-approve`.
 See [Tempo worker roles](https://discourse.charmhub.io/t/tempo-worker-roles/15484) for the recommended scale for each role.

--- a/terraform/modules/tempo/main.tf
+++ b/terraform/modules/tempo/main.tf
@@ -81,8 +81,31 @@ resource "juju_application" "s3_integrator" {
     name    = "s3-integrator"
     channel = var.channel
   }
+  config = {
+    endpoint = var.s3_endpoint
+    bucket   = var.tempo_bucket
+  }
   units = 1
 
+}
+
+resource "terraform_data" "s3management" {
+  depends_on = [
+    juju_application.s3_integrator
+  ]
+  input = {
+    S3_USER       = var.s3_user
+    S3_PASSWORD   = var.s3_password
+    MODEL_NAME    = var.model_name
+    S3_INTEGRATOR = var.s3_integrator_name
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      juju wait-for application -m "${self.input.MODEL_NAME}" "${self.input.S3_INTEGRATOR}" --query='forEach(units,  unit => unit.workload-status=="blocked" && unit.agent-status=="idle")' --timeout=30m
+      juju run -m "${self.input.MODEL_NAME}" "${self.input.S3_INTEGRATOR}/leader" sync-s3-credentials access-key="${self.input.S3_USER}" secret-key="${self.input.S3_PASSWORD}"
+    EOT
+  }
 }
 
 #Integrations

--- a/terraform/modules/tempo/main.tf
+++ b/terraform/modules/tempo/main.tf
@@ -83,7 +83,7 @@ resource "juju_application" "s3_integrator" {
   }
   config = {
     endpoint = var.s3_endpoint
-    bucket   = var.tempo_bucket
+    bucket   = var.s3_bucket
   }
   units = 1
 

--- a/terraform/modules/tempo/outputs.tf
+++ b/terraform/modules/tempo/outputs.tf
@@ -32,11 +32,6 @@ output "endpoints" {
   }
 }
 
-output "tempo_bucket" {
-  value       = var.tempo_bucket
-  description = "The bucket name for Tempo"
-}
-
 output "s3_integrator_name" {
   value       = var.s3_integrator_name
   description = "Name of the s3-integrator for Tempo"

--- a/terraform/modules/tempo/outputs.tf
+++ b/terraform/modules/tempo/outputs.tf
@@ -32,8 +32,8 @@ output "endpoints" {
   }
 }
 
-output "bucket_name" {
-  value       = var.bucket_name
+output "tempo_bucket" {
+  value       = var.tempo_bucket
   description = "The bucket name for Tempo"
 }
 

--- a/terraform/modules/tempo/variables.tf
+++ b/terraform/modules/tempo/variables.tf
@@ -75,7 +75,7 @@ variable "s3_integrator_name" {
   default     = "tempo-s3-integrator"
 }
 
-variable "tempo_bucket" {
+variable "s3_bucket" {
   description = "Bucket name"
   type        = string
   default     = "tempo"

--- a/terraform/modules/tempo/variables.tf
+++ b/terraform/modules/tempo/variables.tf
@@ -69,14 +69,29 @@ variable "query_frontend_units" {
   }
 }
 
-variable "bucket_name" {
-  description = "Model name"
-  type        = string
-  default     = "tempo"
-}
-
 variable "s3_integrator_name" {
   description = "Name of the Loki app with the write role"
   type        = string
   default     = "tempo-s3-integrator"
+}
+
+variable "tempo_bucket" {
+  description = "Bucket name"
+  type        = string
+  default     = "tempo"
+}
+
+variable "s3_user" {
+  description = "S3 user"
+  type        = string
+}
+
+variable "s3_password" {
+  description = "S3 password"
+  type        = string
+}
+
+variable "s3_endpoint" {
+  description = "S3 endpoint"
+  type        = string
 }


### PR DESCRIPTION
This PR improves COS terraform modules by deprecating the use of MinIO variables as an object storage in favour of only using [`s3-integrator` charm](https://charmhub.io/s3-integrator) variables.

Now `loki`, `mimir` and `tempo` modules receives as an argument `s3_user`, `s3_password`, `s3_endpoint` and `[loki|mimir|tempo]_bucket` so they can use these values to configure `s3-integrator` charms.

Related to issue #247

# How to test it.

Just follow the instructions in the documentation post: https://discourse.charmhub.io/t/how-to-deploy-cos-in-a-distributed-with-terraform/15878