### PR TITLE
chore: pin tj-actions/changed-files to the hash of 46.0.1 version

### DIFF
--- a/.github/workflows/bundle-pull-request.yaml
+++ b/.github/workflows/bundle-pull-request.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Determine changed files in the PR
         id: changed-files
-        uses: tj-actions/changed-files@v43
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
         with:
           files_ignore: |
             README.md

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Determine changed files in the PR
         id: changed-files
-        uses: tj-actions/changed-files@v43
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
         with:
           files_ignore: |
             README.md

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Determine changed files in the PR
         id: changed-files
-        uses: tj-actions/changed-files@v43
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
         with:
           files_ignore: |
             README.md

--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Find rockcraft.yaml changes
         id: changed-files
-        uses: tj-actions/changed-files@v43
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
         with:
           files: "**/rockcraft.yaml"
       - name: Extract the versions

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 2 # Needed to check modified files
       - name: Get the changed rockcraft.yaml files
         id: changed-files
-        uses: tj-actions/changed-files@v43
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
         with:
           path: rock
           files: '**/rockcraft.yaml'


### PR DESCRIPTION
After the vulnerability detected in the tj-actions/changed-files, all issues are fixed and a version was released with the issue being resolved. Let's pin to the git SHA of the version until we get rid of the action at all with a git diff equiavalent.

Link to new release of tj-actions/changed-files: https://github.com/tj-actions/changed-files/releases/tag/v46.0.1