### PR TITLE
fix-var-name-for-self-signed-certs

### DIFF
--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -48,10 +48,10 @@ module "mimir" {
 }
 
 module "ssc" {
-  count      = var.use_tls ? 1 : 0
-  source     = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
-  model      = var.model_name
-  channel    = var.channel
+  count   = var.use_tls ? 1 : 0
+  source  = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
+  model   = var.model_name
+  channel = var.channel
 }
 
 module "tempo" {

--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -50,7 +50,7 @@ module "mimir" {
 module "ssc" {
   count      = var.use_tls ? 1 : 0
   source     = "git::https://github.com/canonical/self-signed-certificates-operator//terraform"
-  model_name = var.model_name
+  model      = var.model_name
   channel    = var.channel
 }
 


### PR DESCRIPTION
The self-signed-certs module changed a variable name. This PR fixes the COS module.