### PR TITLE
Workflows for running a security scan on charms and rocks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - self-hosted-linux-amd64-jammy-private-endpoint-medium

--- a/.github/workflows/_secscan.yaml
+++ b/.github/workflows/_secscan.yaml
@@ -1,0 +1,55 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: secscan
+on:
+  workflow_call:
+    inputs:
+      artifacts-type:
+        description: Type of the artifacts, parameter to be used by secscan type modifier
+        required: false
+        default: package
+        type: string
+      artifacts-format:
+        description: Format of the artifacts, parameter to be used by secscan format modifier
+        required: true
+        type: string
+      artifacts-key:
+        description: Key where the artifacts have been uploaded.
+        required: true
+        type: string
+      artifact-path:
+        description: Path where the artifacts have been uploaded.
+        required: true
+        type: string
+jobs:
+  secscan:
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    steps:
+      - name: Install secscan cli
+        run: |
+          sudo snap install canonical-secscan-client
+          sudo snap connect canonical-secscan-client:home system:home
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifacts-key }}
+      - name: Run secscan
+        id: secscan
+        continue-on-error: true
+        run: secscan-client --batch submit --scanner trivy --type ${{ inputs.artifacts-type }} --format ${{ inputs.artifacts-format }} ${{ inputs.artifacts-path }} --token token.yaml
+      - name: Wait for the results
+        id: secscan-wait
+        continue-on-error: true
+        run: secscan-client wait --token token.yaml
+      - name: Show result
+        id: secscan-result
+        run: secscan-client result --token token.yaml
+      - name: Print report
+        id: secscan-report
+        run: secscan-client report --token token.yaml > report.html
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: secscan-report-upload
+          path: report.html

--- a/.github/workflows/_secscan.yaml
+++ b/.github/workflows/_secscan.yaml
@@ -40,14 +40,7 @@ jobs:
       - name: Run secscan
         id: secscan
         continue-on-error: true
-        run: secscan-client --batch submit --scanner trivy --type ${{ inputs.artifacts-type }} --format ${{ inputs.artifacts-format }} ${{ inputs.artifact-path }} --token token.yaml
-      - name: Wait for the results
-        id: secscan-wait
-        continue-on-error: true
-        run: secscan-client wait --token token.yaml
-      - name: Show result
-        id: secscan-result
-        run: secscan-client result --token token.yaml
+        run: secscan-client --batch submit --scanner trivy --type ${{ inputs.artifacts-type }} --format ${{ inputs.artifacts-format }} ${{ inputs.artifact-path }} --token token.yaml --wait-and-print
       - name: Print report
         id: secscan-report
         run: secscan-client report --token token.yaml > report.html

--- a/.github/workflows/_secscan.yaml
+++ b/.github/workflows/_secscan.yaml
@@ -34,6 +34,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifacts-key }}
+      - name: List contents
+        run: ls
       - name: Run secscan
         id: secscan
         continue-on-error: true

--- a/.github/workflows/_secscan.yaml
+++ b/.github/workflows/_secscan.yaml
@@ -34,9 +34,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifacts-key }}
-      - name: Print directory contents
-        id: print
-        run: ls
       - name: Run secscan
         id: secscan
         continue-on-error: true

--- a/.github/workflows/_secscan.yaml
+++ b/.github/workflows/_secscan.yaml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifacts-key }}
+      - name: Print directory contents
+        id: print
+        run: ls
       - name: Run secscan
         id: secscan
         continue-on-error: true

--- a/.github/workflows/_secscan.yaml
+++ b/.github/workflows/_secscan.yaml
@@ -38,6 +38,9 @@ jobs:
         run: ls
       - name: Run secscan
         id: secscan
+        # We want to continue on error as secscan-client returns error code if it finds any perceived vulnerabilities.
+        # However, the `submit` output prints only names of each vulnerability so we want to still get the report
+        # with the severity and more links to the actual issue and dependency.
         continue-on-error: true
         run: secscan-client --batch submit --scanner trivy --type ${{ inputs.artifacts-type }} --format ${{ inputs.artifacts-format }} ${{ inputs.artifact-path }} --token token.yaml --wait-and-print
       - name: Print report

--- a/.github/workflows/_secscan.yaml
+++ b/.github/workflows/_secscan.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Run secscan
         id: secscan
         continue-on-error: true
-        run: secscan-client --batch submit --scanner trivy --type ${{ inputs.artifacts-type }} --format ${{ inputs.artifacts-format }} ${{ inputs.artifacts-path }} --token token.yaml
+        run: secscan-client --batch submit --scanner trivy --type ${{ inputs.artifacts-type }} --format ${{ inputs.artifacts-format }} ${{ inputs.artifact-path }} --token token.yaml
       - name: Wait for the results
         id: secscan-wait
         continue-on-error: true

--- a/.github/workflows/charm-sec-scan.yaml
+++ b/.github/workflows/charm-sec-scan.yaml
@@ -19,11 +19,6 @@ on:
         default: '.'
         required: false
         type: string
-      repository:
-        description: "Repository that we want to run the scan for."
-        default: ${{ github.event.repository.name }}
-        required: false
-        type: string
   workflow_call:
     inputs:
       charmcraft-channel:
@@ -37,11 +32,6 @@ on:
         default: '.'
         required: false
         type: string
-      repository:
-        description: "Repository that we want to run the scan for."
-        default: ${{ github.event.repository.name }}
-        required: false
-        type: string
 
 jobs:
   pack:
@@ -52,7 +42,7 @@ jobs:
       - name: Checkout the project
         uses: actions/checkout@v4
         with:
-          repository: canonical/${{ inputs.repository }}
+          repository: canonical/${{ github.event.repository.name }}
       - name: Install dependencies
         env:
           CHARMCRAFT_CHANNEL: ${{ inputs.charmcraft-channel }}
@@ -84,12 +74,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /home/runner/snap/charmcraft/common/cache/charmcraft
-          key: ${{ runner.os }}-wheel-cache-${{ hashFiles('./uv.lock') }}
+          key: ubuntu-wheel-cache-${{ hashFiles('./uv.lock') }}
           # If the above cache key doesn't match, it's because the uv.lock has changed.
           # Even so, pre-existing caches may still contain useful cached builds for some
           # portion of the dependencies, and restore-keys can partially match a cache.
           restore-keys: |
-            ${{ runner.os }}-wheel-cache-
+            ubuntu-wheel-cache-
       - name: Pack charm(s)
         id: pack
         run: |
@@ -101,7 +91,7 @@ jobs:
       - name: Store charm(s)
         uses: actions/upload-artifact@v4
         with:
-          name: charms-${{ runner.arch }}
+          name: charms-amd64
           path: ${{ inputs.charm-path }}/*.charm
   scan:
     name: Run the security scan
@@ -111,5 +101,5 @@ jobs:
     with:
       artifacts-type: package
       artifacts-format: charm
-      artifacts-key: charms-${{ runner.arch }}
+      artifacts-key: charms-amd64
       artifact-path: ${{ inputs.charm-path }}/*.charm

--- a/.github/workflows/charm-sec-scan.yaml
+++ b/.github/workflows/charm-sec-scan.yaml
@@ -24,6 +24,24 @@ on:
         default: ${{ github.event.repository.name }}
         required: false
         type: string
+  workflow_call:
+    inputs:
+      charmcraft-channel:
+        type: string
+        default: "3.x/candidate"
+        required: false
+        description: |
+          The snap channel from which to install Charmcraft.
+      charm-path:
+        description: "Path to the charm we want to publish. Defaults to the current working directory."
+        default: '.'
+        required: false
+        type: string
+      repository:
+        description: "Repository that we want to run the scan for."
+        default: ${{ github.event.repository.name }}
+        required: false
+        type: string
 
 jobs:
   pack:

--- a/.github/workflows/charm-sec-scan.yaml
+++ b/.github/workflows/charm-sec-scan.yaml
@@ -107,7 +107,7 @@ jobs:
     name: Run the security scan
     needs:
       - pack
-    uses: canonical/observability/.github/workflows/_secscan.yaml@main
+    uses: canonical/observability/.github/workflows/_secscan.yaml@feat/secscan
     with:
       artifacts-type: package
       artifacts-format: charm

--- a/.github/workflows/charm-sec-scan.yaml
+++ b/.github/workflows/charm-sec-scan.yaml
@@ -6,7 +6,7 @@
 name: Security vulnerability scan
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       charmcraft-channel:
         type: string
@@ -19,6 +19,11 @@ on:
         default: '.'
         required: false
         type: string
+      repository:
+        description: "Repository that we want to run the scan for."
+        default: ${{ github.event.repository.name }}
+        required: false
+        type: string
 
 jobs:
   pack:
@@ -29,7 +34,7 @@ jobs:
       - name: Checkout the project
         uses: actions/checkout@v4
         with:
-          repository: canonical/${{ github.event.repository.name }}
+          repository: canonical/${{ inputs.repository }}
       - name: Install dependencies
         env:
           CHARMCRAFT_CHANNEL: ${{ inputs.charmcraft-channel }}

--- a/.github/workflows/charm-sec-scan.yaml
+++ b/.github/workflows/charm-sec-scan.yaml
@@ -84,7 +84,7 @@ jobs:
     name: Run the security scan
     needs:
       - pack
-    uses: canonical/observability/.github/workflows/_secscan@main
+    uses: canonical/observability/.github/workflows/_secscan.yaml@main
     with:
       artifacts-type: package
       artifacts-format: charm

--- a/.github/workflows/charm-sec-scan.yaml
+++ b/.github/workflows/charm-sec-scan.yaml
@@ -8,7 +8,17 @@ name: Security vulnerability scan
 on:
   workflow_call:
     inputs:
-
+      charmcraft-channel:
+        type: string
+        default: "3.x/candidate"
+        required: false
+        description: |
+          The snap channel from which to install Charmcraft.
+      charm-path:
+        description: "Path to the charm we want to publish. Defaults to the current working directory."
+        default: '.'
+        required: false
+        type: string
 
 jobs:
   pack:
@@ -70,10 +80,13 @@ jobs:
         with:
           name: charms-${{ runner.arch }}
           path: ${{ inputs.charm-path }}/*.charm
-      - name: Run a security scan
-        uses: canonical/observability/.github/workflows/_secscan@main
-        with:
-          artifacts-type: package
-          artifacts-format: charm
-          artifacts-key: charms-${{ runner.arch }}
-          artifact-path: ${{ inputs.charm-path }}/*.charm
+  scan:
+    name: Run the security scan
+    needs:
+      - pack
+    uses: canonical/observability/.github/workflows/_secscan@main
+    with:
+      artifacts-type: package
+      artifacts-format: charm
+      artifacts-key: charms-${{ runner.arch }}
+      artifact-path: ${{ inputs.charm-path }}/*.charm

--- a/.github/workflows/charm-sec-scan.yaml
+++ b/.github/workflows/charm-sec-scan.yaml
@@ -1,0 +1,79 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Usage documentation: static-code-analysis.md
+
+name: Security vulnerability scan
+
+on:
+  workflow_call:
+    inputs:
+
+
+jobs:
+  pack:
+    name: Pack the charm
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v4
+        with:
+          repository: canonical/${{ github.event.repository.name }}
+      - name: Install dependencies
+        env:
+          CHARMCRAFT_CHANNEL: ${{ inputs.charmcraft-channel }}
+        run: |
+          # Install LXD
+          # concierge breaks charmcraft: https://github.com/jnsgruk/concierge/issues/28
+          sudo snap install lxd
+          sudo lxd waitready
+          sudo lxd init --minimal
+          sudo lxc network set lxdbr0 ipv6.address none
+          # Enable non-root user control
+          sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+          lxd_user="$USER"
+          sudo usermod -a -G lxd "$lxd_user"
+          # Ensure that LXD containers can talk to the internet
+          sudo iptables -F FORWARD
+          sudo iptables -P FORWARD ACCEPT
+          # Install other snaps
+          sudo snap install charmcraft --classic --channel="$CHARMCRAFT_CHANNEL"
+          sudo snap install astral-uv --classic
+      - name: Get charm name
+        id: get-charm-name
+        run: |
+          # Read charm name from metadata.yaml or charmcraft.yaml
+          cd "${{ inputs.charm-path }}"
+          charm_name=$(yq .name metadata.yaml 2>/dev/null || yq .name charmcraft.yaml)
+          echo "charm_name=$charm_name" >> "$GITHUB_OUTPUT"
+      - name: Cache wheels
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/snap/charmcraft/common/cache/charmcraft
+          key: ${{ runner.os }}-wheel-cache-${{ hashFiles('./uv.lock') }}
+          # If the above cache key doesn't match, it's because the uv.lock has changed.
+          # Even so, pre-existing caches may still contain useful cached builds for some
+          # portion of the dependencies, and restore-keys can partially match a cache.
+          restore-keys: |
+            ${{ runner.os }}-wheel-cache-
+      - name: Pack charm(s)
+        id: pack
+        run: |
+          cd "${{ inputs.charm-path }}"
+          charmcraft pack -v
+          charms="$(basename -a ./*.charm | jq -R -s -c 'split("\n")[:-1]')"
+          echo "charms=$charms"
+          echo "charms=$charms" >> "$GITHUB_OUTPUT"
+      - name: Store charm(s)
+        uses: actions/upload-artifact@v4
+        with:
+          name: charms-${{ runner.arch }}
+          path: ${{ inputs.charm-path }}/*.charm
+      - name: Run a security scan
+        uses: canonical/observability/.github/workflows/_secscan@main
+        with:
+          artifacts-type: package
+          artifacts-format: charm
+          artifacts-key: charms-${{ runner.arch }}
+          artifact-path: ${{ inputs.charm-path }}/*.charm

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -56,4 +56,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.rock-name }}-rock
-        path: "${{ inputs.rock-name }}_*.rock"
+        path: "./**/${{ inputs.rock-name }}_*.rock"

--- a/.github/workflows/rock-sec-scan.yaml
+++ b/.github/workflows/rock-sec-scan.yaml
@@ -1,0 +1,39 @@
+name: Run a security scan for the rock
+
+on:
+  workflow_call:
+    inputs:
+      rock-name:
+        description: "Name of the application for which to build the rock"
+        required: true
+        type: string
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo snap install concierge --classic
+        sudo concierge prepare -p microk8s --extra-snaps=just,yq
+    - name: Build rock
+      run: |
+        latest_version="$(find . -maxdepth 1 -type d -name '[0-9]*' | sort -V | tail -n1 | sed 's@./@@')"
+        just pack "$latest_version"
+    - name: Upload locally built rock artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.rock-name }}-rock
+        path: "${{ inputs.rock-name }}_*.rock"
+  scan:
+    name: Run the security scan
+    needs:
+      - pack
+    uses: canonical/observability/.github/workflows/_secscan.yaml@feat/secscan
+    with:
+      artifacts-type: container-image
+      artifacts-format: oci
+      artifacts-key: ${{ inputs.rock-name }}-rock
+      artifact-path: "${{ inputs.rock-name }}_*.rock"

--- a/.github/workflows/rock-sec-scan.yaml
+++ b/.github/workflows/rock-sec-scan.yaml
@@ -36,4 +36,4 @@ jobs:
       artifacts-type: container-image
       artifacts-format: oci
       artifacts-key: ${{ inputs.rock-name }}-rock
-      artifact-path: "${{ inputs.rock-name }}_*.rock"
+      artifact-path: "./**/${{ inputs.rock-name }}_*.rock"

--- a/.github/workflows/rock-sec-scan.yaml
+++ b/.github/workflows/rock-sec-scan.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.rock-name }}-rock
-        path: "${{ inputs.rock-name }}_*.rock"
+        path: "./**/${{ inputs.rock-name }}_*.rock"
   scan:
     name: Run the security scan
     needs:

--- a/.github/workflows/rock-sec-scan.yaml
+++ b/.github/workflows/rock-sec-scan.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       rock-name:
-        description: "Name of the application for which to build the rock"
+        description: "Name of the rock"
         required: true
         type: string
 


### PR DESCRIPTION
This PR adds a security vulnerability scan (using https://snapcraft.io/canonical-secscan-client ) to the list of available workflows. The workflows are prepared to work with charms and rocks.

Note that the get report action doesn't work yet due to an issue with security-scan backend preventing from using tokens ATM - this was reported to the relevant team.

The idea for this scan use is to generate a report periodically in a similar manner to TIOBE scans. The results will give us an overview of the issues that the scanners currently detect, as a CI run artifact. The pipeline packs a charm/rock to send it to the security scan server for assessment and returns a list of detected CVEs in the build log. After the issue above is fixed, it will also generate an HTML report added as a run artifact.

Sample runs: 
Charm: https://github.com/canonical/o11y-tester-operator/pull/6
Rock: https://github.com/canonical/tempo-rock/pull/32