### PR TITLE
feat(ci): add configurable git-branch for charm-update-libs

### DIFF
--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -58,7 +58,7 @@ jobs:
           is_pr_open="$(gh pr list --head "${{ inputs.git-branch }}" --state open --json id --jq 'length')"
           if [[ "$is_pr_open" == "1" ]]; then
             if gh pr checks "${{ inputs.git-branch }}"; then
-              echo "CI checks are passing, merging the "${{ inputs.git-branch }}" PR"
+              echo "CI checks are passing, merging the ${{ inputs.git-branch }} PR"
               gh pr merge "${{ inputs.git-branch }}" --admin --squash --delete-branch
             fi
           elif [[ "$is_pr_open" != "0" ]]; then

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -4,17 +4,22 @@ on:
     inputs:
       charm-path:
         description: "Path to the charm we want to publish. Defaults to the current working directory."
-        default: '.'
+        default: "."
+        required: false
+        type: string
+      git-branch:
+        description: "Branch name for the chore. Defaults to 'chore/auto-libs'."
+        default: "chore/auto-libs"
         required: false
         type: string
       commit-username:
         description: "The username to use for committing the updates on the charm libraries"
-        default: 'Noctua'
+        default: "Noctua"
         required: false
         type: string
       commit-email:
         description: "The email address to use for committing the updates on the charm libraries"
-        default: 'webops+observability-noctua-bot@canonical.com'
+        default: "webops+observability-noctua-bot@canonical.com"
         required: false
         type: string
       charmcraft-channel:
@@ -47,14 +52,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Merge any pre-existing PRs from the automatically generated "chore/auto-libs" branch if the CI is green
+      - name: Merge any pre-existing PRs from the automatically generated branch if the CI is green
         run: |
-          # If a PR from "chore/auto-libs" is open and CI checks are passing, merge it
-          is_pr_open="$(gh pr list --head chore/auto-libs --state open --json id --jq 'length')"
+          # If a PR from the chore branch is open and CI checks are passing, merge it
+          is_pr_open="$(gh pr list --head "${{ inputs.git-branch }}" --state open --json id --jq 'length')"
           if [[ "$is_pr_open" == "1" ]]; then
-            if gh pr checks chore/auto-libs; then
-              echo "CI checks are passing, merging the chore/auto-libs PR"
-              gh pr merge chore/auto-libs --admin --squash --delete-branch
+            if gh pr checks "${{ inputs.git-branch }}"; then
+              echo "CI checks are passing, merging the "${{ inputs.git-branch }}" PR"
+              gh pr merge "${{ inputs.git-branch }}" --admin --squash --delete-branch
             fi
           elif [[ "$is_pr_open" != "0" ]]; then
             # The number of open PRs should always be either 0 or 1
@@ -146,5 +151,5 @@ jobs:
             most likely don't want to push any commits to this branch.
 
             The PR will be auto-merged if the CI is green, on the next iteration of the workflow.
-          branch: chore/auto-libs
+          branch: "${{ inputs.git-branch }}"
           delete-branch: true

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       git-branch:
-        description: "Branch name for the chore. Defaults to 'chore/auto-libs'."
+        description: "Branch name for the charm library update. Defaults to 'chore/auto-libs'."
         default: "chore/auto-libs"
         required: false
         type: string

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -46,6 +46,8 @@ jobs:
   update-lib:
     name: Check libraries
     runs-on: ubuntu-22.04
+    env:
+      GIT_BRANCH: ${{ inputs.git-branch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,11 +57,11 @@ jobs:
       - name: Merge any pre-existing PRs from the automatically generated branch if the CI is green
         run: |
           # If a PR from the chore branch is open and CI checks are passing, merge it
-          is_pr_open="$(gh pr list --head "${{ inputs.git-branch }}" --state open --json id --jq 'length')"
+          is_pr_open="$(gh pr list --head "$GIT_BRANCH" --state open --json id --jq 'length')"
           if [[ "$is_pr_open" == "1" ]]; then
-            if gh pr checks "${{ inputs.git-branch }}"; then
-              echo "CI checks are passing, merging the ${{ inputs.git-branch }} PR"
-              gh pr merge "${{ inputs.git-branch }}" --admin --squash --delete-branch
+            if gh pr checks "$GIT_BRANCH"; then
+              echo "CI checks are passing, merging the $GIT_BRANCH PR"
+              gh pr merge "$GIT_BRANCH" --admin --squash --delete-branch
             fi
           elif [[ "$is_pr_open" != "0" ]]; then
             # The number of open PRs should always be either 0 or 1
@@ -151,5 +153,5 @@ jobs:
             most likely don't want to push any commits to this branch.
 
             The PR will be auto-merged if the CI is green, on the next iteration of the workflow.
-          branch: "${{ inputs.git-branch }}"
+          branch: "$GIT_BRANCH"
           delete-branch: true


### PR DESCRIPTION
Resolves #286

In repositories that have a monorepo structure, there may be multiple charms within a single repo. The current workflow will use the same `chore/auto-libs` branch for both runs of the workflow, and will override changes that may have been relevant to the other charm.

This adds a `git-branch` optional input so that, in those scenarios, we can use a custom branch name for each workflow run (e.g., `chore/auto-libs-agent` and `chore/auto-libs-server`)