### PR TITLE
fix: build arm charms with user belonging to lxd group

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -100,6 +100,8 @@ jobs:
           sudo snap install lxd
           sudo lxd init --auto
           sudo snap install charmcraft --classic --channel="${{ inputs.charmcraft-channel }}"
+          lxd_user="$USER"
+          sudo usermod -a -G lxd "$lxd_user"
       - name: Build charm(s)
         id: builder
         run: |


### PR DESCRIPTION
Add workflow user to lxd group to allow running `charmcraft pack` and stop receiving the error below:

```bash
Run (cd maas-region; charmcraft pack)
  (cd maas-region; charmcraft pack)
  export CHARMS=$(basename -a maas-region/*.charm | jq -R -s -c 'split("\n")[:-1]')
  echo "charms=$CHARMS" >> "$GITHUB_OUTPUT"
  shell: /usr/bin/bash -e {0}
  
LXD requires additional permissions.
Recommended resolution: Ensure that the user is in the 'lxd' group.
Visit https://documentation.ubuntu.com/lxd/en/latest/getting_started/ for instructions on installing and configuring LXD for your operating system.
Full execution log: '/home/runner/.local/state/charmcraft/log/charmcraft-20250417-114811.216917.log'
Error: Process completed with exit code 1.
```