### PR TITLE
fix: resolve network issue on arm runner

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -103,6 +103,9 @@ jobs:
           # Enable non-root user control
           sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
           sudo lxc network set lxdbr0 ipv6.address none
+          # Ensure that LXD containers can talk to the internet
+          sudo iptables -F FORWARD
+          sudo iptables -P FORWARD ACCEPT
           sudo snap install charmcraft --classic --channel="${{ inputs.charmcraft-channel }}"
           lxd_user="$USER"
           sudo usermod -a -G lxd "$lxd_user"


### PR DESCRIPTION
Bringing the iptables changes from v1 as an attempt to fix network access issue during `charmcraft pack`:

```bash
Run sg lxd -c "(cd maas-region; charmcraft pack)"
  
Launching managed ubuntu 24.04 instance...
Creating new instance from remote
Creating new base instance from remote
A network related operation failed in a context of no network access.
Recommended resolution: Verify that the environment has internet connectivity; see https://canonical-craft-providers.readthedocs-hosted.com/en/latest/explanation/ for further reference.
Full execution log: '/home/runner/.local/state/charmcraft/log/charmcraft-20250417-135610.513234.log'
Error: Process completed with exit code 1.
```