### PR TITLE
Fix `charm-tiobe-scan` workflow

### DIFF
--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -1,8 +1,6 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# Usage documentation: static-code-analysis.md
-
 name: Tiobe TiCS Analysis
 
 on:
@@ -26,6 +24,7 @@ jobs:
           pipx install coverage
           pipx install "coverage[toml]"
           pipx install tox
+          sudo snap install astral-uv --classic
 
       - name: Run tox tests to create coverage.xml
         run: |

--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run tox tests to create coverage.xml
         run: |
-          tox -e unit && coverage xml -o coverage/coverage.xml
+          tox -e unit && coverage xml -o .cover/cobertura.xml
 
       - name: Activate and prepare Python virtual environment
         run: |

--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -28,12 +28,7 @@ jobs:
 
       - name: Run tox tests to create coverage.xml
         run: |
-          tox -e unit && coverage xml
-
-      - name: Move results to necessary folder for TICS
-        run: |
-          mkdir -p ./cover
-          mv ./coverage.xml ./cover/
+          tox -e unit && coverage xml -o coverage/coverage.xml
 
       - name: Activate and prepare Python virtual environment
         run: |


### PR DESCRIPTION
## Issue
Tiobe scans are failing due to:
- missing `uv` package
https://github.com/canonical/tempo-coordinator-k8s-operator/actions/runs/14697764120/job/41241924636
- `tiobe/tics-github-action@v3` action expects the coverage file to be in `.cover/cobertura.xml`

## Solution
- Install `uv` snap
- Rename coverage file to `cobertura.xml`

## Testing considerations
Tandem PR: https://github.com/canonical/o11y-tester-operator/pull/9