### PR TITLE
Provision Mimir, Loki and Tempo coordinator units first

### DIFF
--- a/terraform/modules/loki/main.tf
+++ b/terraform/modules/loki/main.tf
@@ -50,6 +50,9 @@ module "loki_backend" {
     role-backend = true
   }
   units = var.backend_units
+  depends_on = [
+    module.loki_coordinator
+  ]
 }
 
 module "loki_read" {
@@ -61,6 +64,9 @@ module "loki_read" {
     role-read = true
   }
   units = var.read_units
+  depends_on = [
+    module.loki_coordinator
+  ]
 }
 
 module "loki_write" {
@@ -72,6 +78,9 @@ module "loki_write" {
     role-write = true
   }
   units = var.write_units
+  depends_on = [
+    module.loki_coordinator
+  ]
 }
 
 # -------------- # Integrations --------------

--- a/terraform/modules/mimir/main.tf
+++ b/terraform/modules/mimir/main.tf
@@ -52,6 +52,9 @@ module "mimir_read" {
     role-read = true
   }
   units = var.read_units
+  depends_on = [
+    module.mimir_coordinator
+  ]
 }
 
 module "mimir_write" {
@@ -63,6 +66,9 @@ module "mimir_write" {
     role-write = true
   }
   units = var.write_units
+  depends_on = [
+    module.mimir_coordinator
+  ]
 }
 
 module "mimir_backend" {
@@ -74,6 +80,9 @@ module "mimir_backend" {
     role-backend = true
   }
   units = var.backend_units
+  depends_on = [
+    module.mimir_coordinator
+  ]
 }
 
 # -------------- # Integrations --------------

--- a/terraform/modules/tempo/main.tf
+++ b/terraform/modules/tempo/main.tf
@@ -14,6 +14,9 @@ module "tempo_querier" {
     role-querier = true
   }
   units = var.querier_units
+  depends_on = [
+    module.tempo_coordinator
+  ]
 }
 module "tempo_query_frontend" {
   source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
@@ -25,6 +28,9 @@ module "tempo_query_frontend" {
     role-query-frontend = true
   }
   units = var.query_frontend_units
+  depends_on = [
+    module.tempo_coordinator
+  ]
 }
 module "tempo_ingester" {
   source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
@@ -36,6 +42,9 @@ module "tempo_ingester" {
     role-ingester = true
   }
   units = var.ingester_units
+  depends_on = [
+    module.tempo_coordinator
+  ]
 }
 module "tempo_distributor" {
   source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
@@ -47,6 +56,9 @@ module "tempo_distributor" {
     role-distributor = true
   }
   units = var.distributor_units
+  depends_on = [
+    module.tempo_coordinator
+  ]
 }
 module "tempo_compactor" {
   source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
@@ -58,6 +70,9 @@ module "tempo_compactor" {
     role-compactor = true
   }
   units = var.compactor_units
+  depends_on = [
+    module.tempo_coordinator
+  ]
 }
 module "tempo_metrics_generator" {
   source     = "git::https://github.com/canonical/tempo-worker-k8s-operator//terraform"
@@ -69,6 +84,9 @@ module "tempo_metrics_generator" {
     role-metrics-generator = true
   }
   units = var.metrics_generator_units
+  depends_on = [
+    module.tempo_coordinator
+  ]
 }
 
 # TODO: Replace s3_integrator resource to use its remote terraform module once available


### PR DESCRIPTION
Fixes #311 

The [depends_on](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) meta-argument:
> When the dependency object is an entire module, it affects the order in which Terraform processes all of the resources and data sources associated with that module.