### PR TITLE
Support specifying the number of Loki, Mimir and Tempo coordinator units to run in Terraform

### DIFF
--- a/terraform/modules/cos/README.md
+++ b/terraform/modules/cos/README.md
@@ -33,15 +33,18 @@ The module offers the following configurable inputs:
 | `loki_backend_units` | number | Number of Loki worker units with `backend` role                |
 | `loki_read_units` | number | Number of Loki worker units with `read` role                   |
 | `loki_write_units` | number | Number of Loki worker units with `write` role                  |
+| `loki_coordinator_units` | number | Number of Loki coordinator units                 |
 | `mimir_backend_units` | number | Number of Mimir worker units with `backend` role               |
 | `mimir_read_units` | number | Number of Mimir worker units with `read` role                  |
 | `mimir_write_units` | number | Number of Mimir worker units with `write` role                 |
+| `mimir_coordinator_units` | number | Number of Mimir coordinator units                 |
 | `tempo_compactor_units` | number | Number of Tempo worker units with `compactor` role             |
 | `tempo_distributor_units` | number | Number of Tempo worker units with `distributor` role           |
 | `tempo_ingester_units` | number | Number of Tempo worker units with `ingester` role              |
 | `tempo_metrics_generator_units` | number | Number of Tempo worker units with `metrics_generator` role     |
 | `tempo_querier_units` | number | Number of Tempo worker units with `querier` role               |
 | `tempo_query_frontend_units` | number | Number of Tempo worker units with `query_frontend` role        |
+| `tempo_coordinator_units` | number | Number of Tempo coordinator units        |
 | `s3_user` | string | S3 provider username credential                                | 1 |
 | `s3_password` | string | S3 provider password credential                                | 1 |
 | `s3_endpoint` | string | S3 provider endpoint                                           | 1 |

--- a/terraform/modules/cos/main.tf
+++ b/terraform/modules/cos/main.tf
@@ -22,30 +22,31 @@ module "grafana" {
 }
 
 module "loki" {
-  source        = "git::https://github.com/canonical/observability//terraform/modules/loki"
-  model_name    = var.model_name
-  channel       = var.channel
-  backend_units = var.loki_backend_units
-  read_units    = var.loki_read_units
-  write_units   = var.loki_write_units
-  s3_bucket     = var.loki_bucket
-  s3_endpoint   = var.s3_endpoint
-  s3_password   = var.s3_password
-  s3_user       = var.s3_user
+  source            = "git::https://github.com/canonical/observability//terraform/modules/loki"
+  model_name        = var.model_name
+  channel           = var.channel
+  backend_units     = var.loki_backend_units
+  read_units        = var.loki_read_units
+  write_units       = var.loki_write_units
+  coordinator_units = var.coordinator_units
+  s3_bucket         = var.loki_bucket
+  s3_endpoint       = var.s3_endpoint
+  s3_password       = var.s3_password
+  s3_user           = var.s3_user
 }
 
 module "mimir" {
-  source        = "git::https://github.com/canonical/observability//terraform/modules/mimir"
-  model_name    = var.model_name
-  channel       = var.channel
-  backend_units = var.mimir_backend_units
-  read_units    = var.mimir_read_units
-  write_units   = var.mimir_write_units
-  s3_bucket     = var.mimir_bucket
-  s3_endpoint   = var.s3_endpoint
-  s3_password   = var.s3_password
-  s3_user       = var.s3_user
-
+  source            = "git::https://github.com/canonical/observability//terraform/modules/mimir"
+  model_name        = var.model_name
+  channel           = var.channel
+  backend_units     = var.mimir_backend_units
+  read_units        = var.mimir_read_units
+  write_units       = var.mimir_write_units
+  coordinator_units = var.coordinator_units
+  s3_bucket         = var.mimir_bucket
+  s3_endpoint       = var.s3_endpoint
+  s3_password       = var.s3_password
+  s3_user           = var.s3_user
 }
 
 module "ssc" {
@@ -65,6 +66,7 @@ module "tempo" {
   metrics_generator_units = var.tempo_metrics_generator_units
   querier_units           = var.tempo_querier_units
   query_frontend_units    = var.tempo_query_frontend_units
+  coordinator_units       = var.coordinator_units
   s3_bucket               = var.tempo_bucket
   s3_endpoint             = var.s3_endpoint
   s3_password             = var.s3_password

--- a/terraform/modules/cos/variables.tf
+++ b/terraform/modules/cos/variables.tf
@@ -72,6 +72,12 @@ variable "loki_write_units" {
   default     = 3
 }
 
+variable "loki_coordinator_units" {
+  description = "Number of Loki coordinator units"
+  type        = number
+  default     = 3
+}
+
 variable "mimir_backend_units" {
   description = "Number of Mimir worker units with backend role"
   type        = number
@@ -86,6 +92,12 @@ variable "mimir_read_units" {
 
 variable "mimir_write_units" {
   description = "Number of Mimir worker units with write role"
+  type        = number
+  default     = 3
+}
+
+variable "mimir_coordinator_units" {
+  description = "Number of Mimir coordinator units"
   type        = number
   default     = 3
 }
@@ -119,8 +131,15 @@ variable "tempo_querier_units" {
   type        = number
   default     = 3
 }
+
 variable "tempo_query_frontend_units" {
   description = "Number of Tempo worker units with query-frontend role"
+  type        = number
+  default     = 3
+}
+
+variable "tempo_coordinator_units" {
+  description = "Number of Tempo coordinator units"
   type        = number
   default     = 3
 }

--- a/terraform/modules/loki/README.md
+++ b/terraform/modules/loki/README.md
@@ -29,6 +29,7 @@ The module offers the following configurable inputs:
 | `model_name`| string | Name of the model that the charm is deployed on |  |
 | `read_units`| number | Number of Loki worker units with the read role | 1 |
 | `write_units`| number | Number of Loki worker units with the write role | 1 |
+| `coordinator_units`| number | Number of Loki coordinator units | 1 |
 | `s3_integrator_name` | string | Name of the s3-integrator app | 1 |
 | `s3_bucket` | string | Name of the bucke in which Loki stores logs | 1 |
 | `s3_user` | string | User to connect to the S3 provider | 1 |

--- a/terraform/modules/loki/main.tf
+++ b/terraform/modules/loki/main.tf
@@ -39,6 +39,7 @@ module "loki_coordinator" {
   app_name   = "loki"
   model_name = var.model_name
   channel    = var.channel
+  units      = var.coordinator_units
 }
 
 module "loki_backend" {

--- a/terraform/modules/loki/variables.tf
+++ b/terraform/modules/loki/variables.tf
@@ -74,3 +74,9 @@ variable "write_units" {
   type        = number
   default     = 1
 }
+
+variable "coordinator_units" {
+  description = "Number of Loki coordinator units"
+  type        = number
+  default     = 1
+}

--- a/terraform/modules/mimir/README.md
+++ b/terraform/modules/mimir/README.md
@@ -36,6 +36,7 @@ The module offers the following configurable inputs:
 | `query_scheduler_units`| number | Number of Mimir worker units with the query-scheduler role | 1 |
 | `ruler_units`| number | Number of Mimir worker units with the ruler role | 1 |
 | `store_gateway_units`| number | Number of Mimir worker units with the store-gateway role | 1 |
+| `coordinator_units`| number | Number of Mimir coordinator units | 1 |
 | `s3_integrator_name` | string | Name of the s3-integrator app | 1 |
 | `s3_bucket` | string | Name of the bucke in which Mimir stores metrics | 1 |
 | `s3_user` | string | User to connect to the S3 provider | 1 |

--- a/terraform/modules/mimir/main.tf
+++ b/terraform/modules/mimir/main.tf
@@ -41,6 +41,7 @@ module "mimir_coordinator" {
   app_name   = "mimir"
   model_name = var.model_name
   channel    = var.channel
+  units      = var.coordinator_units
 }
 
 module "mimir_read" {

--- a/terraform/modules/mimir/variables.tf
+++ b/terraform/modules/mimir/variables.tf
@@ -74,3 +74,9 @@ variable "backend_units" {
   type        = number
   default     = 1
 }
+
+variable "coordinator_units" {
+  description = "Number of Mimir coordinator units"
+  type        = number
+  default     = 1
+}

--- a/terraform/modules/tempo/README.md
+++ b/terraform/modules/tempo/README.md
@@ -32,6 +32,7 @@ The module offers the following configurable inputs:
 | `model_name`| string | Name of the model that the charm is deployed on |  |
 | `querier_units`| number | Number of Tempo worker units with querier role | 1 |
 | `query_frontend_units`| number | Number of Tempo worker units with query-frontend role | 1 |
+| `coordinator_units`| number | Number of Tempo coordinator units | 1 |
 | `s3_integrator_name` | string | Name of the s3-integrator app | 1 |
 | `s3_bucket` | string | Name of the bucke in which Tempo stores traces | 1 |
 | `s3_user` | string | User to connect to the S3 provider | 1 |

--- a/terraform/modules/tempo/main.tf
+++ b/terraform/modules/tempo/main.tf
@@ -2,6 +2,7 @@ module "tempo_coordinator" {
   source     = "git::https://github.com/canonical/tempo-coordinator-k8s-operator//terraform"
   model_name = var.model_name
   channel    = var.channel
+  units      = var.coordinator_units
 }
 
 module "tempo_querier" {

--- a/terraform/modules/tempo/variables.tf
+++ b/terraform/modules/tempo/variables.tf
@@ -44,6 +44,16 @@ variable "metrics_generator_units" {
   }
 }
 
+variable "coordinator_units" {
+  description = "Number of Tempo coordinator units"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.coordinator_units >= 1
+    error_message = "The number of units must be greater than or equal to 1."
+  }
+}
+
 
 variable "model_name" {
   description = "Model name"


### PR DESCRIPTION
Fixes #315 