### PR TITLE
fix: Allow parallel runs of pull-request if charm-path is specified

### DIFF
--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -43,7 +43,7 @@ on:
          required: false
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.ref }}${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
We had an issue with parallel runs of `charm-pull-request` workflow in the pyroscope charm - in a race condition between worker and coordinator, one of the workflow runs canceled the other. It was caused by the concurrency group in the shared workflow.

This PR changes the concurrency group name to include `charm-path` if it's defined and set to anything else than the default.

Open question: should we modify the other shared workflows too?