### PR TITLE
fix: Allow parallel runs per charm-path

### DIFF
--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -19,7 +19,7 @@ on:
         required: true
 
 concurrency:
-  group: quality-gates
+  group: quality-gates${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -56,7 +56,7 @@ on:
         required: true
 
 concurrency:
-  group: release
+  group: release${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
#327, but for the other workflows that allow `charm-path` and use concurrency.