### PR TITLE
Include charm path in artifacts

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -187,7 +187,7 @@ jobs:
       - name: Upload charm artifact
         uses: actions/upload-artifact@v4
         with:
-          name: charms-tests
+          name: charms-tests${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
           path: ${{ inputs.charm-path }}/*.charm
 
   integration-mono:
@@ -211,7 +211,7 @@ jobs:
       - name: Download charm artifact
         uses: actions/download-artifact@v4
         with:
-          name: charms-tests
+          name: charms-tests${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
           path: ${{ inputs.charm-path }}
       - name: Run integration tests
         run: |
@@ -264,7 +264,7 @@ jobs:
       - name: Download charm artifact
         uses: actions/download-artifact@v4
         with:
-          name: charms-tests
+          name: charms-tests${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
           path: ${{ inputs.charm-path }}
       - name: Run integration tests
         run: |

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -114,7 +114,7 @@ jobs:
     needs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
-    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@fix/include-charm-path-in-artifacts
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v1
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -114,7 +114,7 @@ jobs:
     needs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
-    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v1
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@fix/include-charm-path-in-artifacts
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}


### PR DESCRIPTION
If we run integration tests in the same run on multiple charms in parallel, the packed charm artifact from one of the runs gets uploaded, blocking the others from uploading due to artifact name conflict. As a solution, add a `charm-path` suffix to artifacts if it's defined.