### PR TITLE
fix: Add charm-path suffix to stored artifact in release

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Store charm(s)
         uses: actions/upload-artifact@v4
         with:
-          name: charms-${{ runner.arch }}
+          name: charms-${{ runner.arch }}${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
           path: ${{ inputs.charm-path }}/*.charm
       - name: Release charm to Charmhub and GitHub
         id: upload


### PR DESCRIPTION
Context: https://github.com/canonical/pyroscope-k8s-operator/actions/runs/15419484304/job/43394557763