### PR TITLE
Remove empty provider block in cos-lite

### DIFF
--- a/terraform/modules/cos-lite/main.tf
+++ b/terraform/modules/cos-lite/main.tf
@@ -1,7 +1,3 @@
-provider "juju" {
-}
-
-
 # -------------- # Applications --------------
 
 module "ssc" {


### PR DESCRIPTION
This empty provider block isn't necessary anymore and triggers the warning shown below. Not that the juju provider is already declared in the `required_providers` block in the [`cos-lite/versions.tf` file](https://github.com/canonical/observability/blob/3dfdbfb3b9c382fb1fdc00f925952d5e499f63a4/terraform/modules/cos-lite/versions.tf#L4).

```bash
Warning: Redundant empty provider block
│ 
│   on .terraform/modules/cos_lite/terraform/modules/cos-lite/main.tf line 1:
│    1: provider "juju" {
│ 
│ Earlier versions of Terraform used empty provider blocks ("proxy provider configurations") for child modules to declare their need to be passed a provider configuration by their callers. That approach was
│ ambiguous and is now deprecated.
│ 
│ If you control this module, you can migrate to the new declaration syntax by removing all of the empty provider "juju" blocks and then adding or updating an entry like the following to the required_providers
│ block of module.cos_lite:
│     juju = {
│       source = "juju/juju"
│     }
│ 
│ (and one more similar warning elsewhere)
```