### PR TITLE
fix: improve COS Lite terraform module

### DIFF
--- a/terraform/modules/cos-lite/main.tf
+++ b/terraform/modules/cos-lite/main.tf
@@ -352,3 +352,33 @@ resource "juju_integration" "traefik_self_monitoring_prometheus" {
     endpoint = module.traefik.endpoints.metrics_endpoint
   }
 }
+
+# -------------- # Offers --------------
+
+resource "juju_offer" "alertmanager-karma-dashboard" {
+  name             = "alertmanager-karma-dashboard"
+  model            = var.model_name
+  application_name = module.alertmanager.app_name
+  endpoint         = "karma-dashboard"
+}
+
+resource "juju_offer" "grafana-dashboards" {
+  name             = "grafana-dashboards"
+  model            = var.model_name
+  application_name = module.grafana.app_name
+  endpoint         = "grafana-dashboard"
+}
+
+resource "juju_offer" "loki-logging" {
+  name             = "loki-logging"
+  model            = var.model_name
+  application_name = module.loki.app_name
+  endpoint         = "logging"
+}
+
+resource "juju_offer" "prometheus-receive-remote-write" {
+  name             = "prometheus-receive-remote-write"
+  model            = var.model_name
+  application_name = module.prometheus.app_name
+  endpoint         = "receive-remote-write"
+}

--- a/terraform/modules/cos-lite/outputs.tf
+++ b/terraform/modules/cos-lite/outputs.tf
@@ -7,7 +7,6 @@ output "app_names" {
       loki          = module.loki.app_name,
       prometheus    = module.prometheus.app_name,
       traefik       = module.traefik.app_name,
-      grafana_agent = module.grafana_agent.app_name,
     }
   )
 }

--- a/terraform/modules/cos-lite/outputs.tf
+++ b/terraform/modules/cos-lite/outputs.tf
@@ -1,12 +1,12 @@
 output "app_names" {
   value = merge(
     {
-      alertmanager  = module.alertmanager.app_name,
-      catalogue     = module.catalogue.app_name,
-      grafana       = module.grafana.app_name,
-      loki          = module.loki.app_name,
-      prometheus    = module.prometheus.app_name,
-      traefik       = module.traefik.app_name,
+      alertmanager = module.alertmanager.app_name,
+      catalogue    = module.catalogue.app_name,
+      grafana      = module.grafana.app_name,
+      loki         = module.loki.app_name,
+      prometheus   = module.prometheus.app_name,
+      traefik      = module.traefik.app_name,
     }
   )
 }


### PR DESCRIPTION
This PR fixes #334

- remove `grafana-agent` since it is not part of COS-Lite
- add missing relations
- fix relations wrongly defined


# How to test it

1. Deploy `cos-lite` from the bundle in `cos-bundle` model:
   ```shell
   juju add-model cos-bundle
   juju deploy cos-lite --trust
   ```
2. Deploy `cos-lite` using the terraform module in `cos-tf` model:
   ```shell
   juju add-model cos-tf
   terraform init
   terraform apply -var="model_name=cos-tf" -auto-approve
   ```
3. Export Integrations from both models:
   ```shell
   juju status --relations -m cos-bundle | grep -A 40 "Integration provider" > /tmp/cos-lite-bundle.txt
   juju status --relations -m cos-tf | grep -A 40 "Integration provider" > /tmp/cos-lite-tf.txt
   ```
4. Compare both outputs and verify there is no difference between them:
   ```shell
   ╭─ubuntu@charm-dev-36 ~/repos [microk8s:cos-tf]
   ╰─$ diff /tmp/cos-lite-bundle.txt /tmp/cos-lite-tf.txt 
   ╭─ubuntu@charm-dev-36 ~/repos [microk8s:cos-tf]
   ╰─$ 
   ```
5. Export Offers from both models:
   ```shell
   juju status --relations -m cos-bundle | grep -A 4 "Offer" | awk '{print $1}'  > /tmp/offers-cos-bundle.txt

   juju status --relations -m cos-tf | grep -A 4 "Offer" | awk '{print $1}'  > /tmp/offers-cos-tf.txt
   ```
6. Compare both outputs and verify there is no difference between them:
   ```shell
   ╭─ubuntu@charm-dev-36 ~/repos [microk8s:cos-tf]
   ╰─$ diff /tmp/offers-cos-bundle.txt /tmp/offers-cos-tf.txt 
   ╭─ubuntu@charm-dev-36 ~/repos [microk8s:cos-tf]
   ╰─$
   ```