### PR TITLE
feat: Run a tmate session on failing rock PR tests

### DIFF
--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -55,3 +55,9 @@ jobs:
             just test "$version"
             just clean "$version"
           done
+      - name: Open SSH session on failure
+        if: ${{ failure() && (runner.debug == '1') }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          timeout-minutes: 30
+          limit-access-to-actor: true


### PR DESCRIPTION
In rock tests, it's hard to verify what's going on when tests fail. A tmate session might be useful.