### PR TITLE
feat: TF validate in quality check CI

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -131,6 +131,24 @@ jobs:
           cd "$CHARM_PATH"
           tofu fmt -check -recursive -diff
 
+  validate-terraform:
+    name: Validate Terraform module(s)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Terraform and validate modules
+        env:
+          CHARM_PATH: "${{ inputs.charm-path }}"
+        run: |      
+          if [ -d "$CHARM_PATH/terraform" ]; then
+            sudo snap install opentofu --classic
+            cd "$CHARM_PATH/terraform"
+            tofu validate
+          else
+            echo "Terraform directory does not exist. Skipping validation."
+          fi
+
   static-analysis:
     name: Static analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -118,12 +118,12 @@ jobs:
           fi
 
   linting-terraform:
-    name: Lint Terraform files
+    name: Validate Terraform files
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Terraform and lint modules
+      - name: Install Terraform and validate modules
         env:
           CHARM_PATH: "${{ inputs.charm-path }}"
         run: |

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -137,18 +137,6 @@ jobs:
             echo "Terraform directory ($CHARM_PATH/terraform) does not exist. Skipping validation."
           fi
 
-  validate-terraform:
-    name: Validate Terraform module(s)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Terraform and validate modules
-        env:
-          CHARM_PATH: "${{ inputs.charm-path }}"
-        run: |      
-          
-
   static-analysis:
     name: Static analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -130,6 +130,12 @@ jobs:
           sudo snap install opentofu --classic
           cd "$CHARM_PATH"
           tofu fmt -check -recursive -diff
+          if [ -d "$CHARM_PATH/terraform" ]; then
+            cd "$CHARM_PATH/terraform"
+            tofu validate
+          else
+            echo "Terraform directory ($CHARM_PATH/terraform) does not exist. Skipping validation."
+          fi
 
   validate-terraform:
     name: Validate Terraform module(s)
@@ -141,13 +147,7 @@ jobs:
         env:
           CHARM_PATH: "${{ inputs.charm-path }}"
         run: |      
-          if [ -d "$CHARM_PATH/terraform" ]; then
-            sudo snap install opentofu --classic
-            cd "$CHARM_PATH/terraform"
-            tofu validate
-          else
-            echo "Terraform directory does not exist. Skipping validation."
-          fi
+          
 
   static-analysis:
     name: Static analysis

--- a/.github/workflows/_local-pull-request.yaml
+++ b/.github/workflows/_local-pull-request.yaml
@@ -6,18 +6,6 @@ on:
       - main
 
 jobs:
-  lint-terraform:
-    name: Terraform lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          sudo snap install terraform --classic
-          sudo snap install just --classic
-      - name: Lint the Terraform modules
-        run: just lint-terraform
   lint-workflows:
     name: Workflows Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
It would be great if we could have central `tofu validate` commands in CI since _almost_ all our charms will have a terraform module.