### PR TITLE
feat: allow rock-pull-request to work with monorepo, concierge installed snaps configurable

### DIFF
--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -2,6 +2,17 @@ name: Pull Request
 
 on:
   workflow_call:
+    inputs:
+      extra-snaps:
+        description: "Extra snaps to be installed into concierge env where tests will be run"
+        default: 'rockcraft,just,kubectl'
+        required: false
+        type: string
+      rock-path:
+        description: "Path to the rock we want to test. Defaults to the current working directory"
+        default: '.'
+        required: false
+        type: string
 
 
 jobs:
@@ -40,7 +51,7 @@ jobs:
         run: |
           sudo snap install concierge --classic
           # We need the kubectl (classic) snap because `kgoss` needs access to the /tmp directory
-          sudo concierge prepare -p microk8s --extra-snaps rockcraft,just,kubectl
+          sudo concierge prepare -p microk8s --extra-snaps $EXTRA_SNAPS
           sudo microk8s enable registry
           # FIXME: install via the goss snap when available
           goss_base_url="https://github.com/goss-org/goss/releases/latest/download"
@@ -48,8 +59,11 @@ jobs:
           chmod +rx /usr/local/bin/goss
           curl -L ${goss_base_url}/kgoss -o /usr/local/bin/kgoss
           chmod +rx /usr/local/bin/kgoss
+        env:
+          EXTRA_SNAPS: ${{ inputs.extra-snaps }}
       - name: Pack and test the rocks
         run: |
+          cd "${{ inputs.rock-path }}"
           for version in ${{ needs.changes.outputs.versions }}; do
             just pack "$version"
             just test "$version"

--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -8,11 +8,6 @@ on:
         default: 'rockcraft,just,kubectl'
         required: false
         type: string
-      rock-path:
-        description: "Path to the home directory of the rock we want to test"
-        default: "."
-        required: false
-        type: string
 
 
 jobs:
@@ -63,12 +58,16 @@ jobs:
           EXTRA_SNAPS: ${{ inputs.extra-snaps }}
       - name: Pack and test the rocks
         run: |
-          cd "${{ inputs.rock-path }}"
           for version in ${{ needs.changes.outputs.versions }}; do
             version_leaf_directory="${version##*/}"
+
+            cd "${version%/$version_leaf_directory}"
+
             just pack "$version_leaf_directory"
             just test "$version_leaf_directory"
             just clean "$version_leaf_directory"
+
+            cd -
           done
       - name: Open SSH session on failure
         if: ${{ failure() && (runner.debug == '1') }}

--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo snap install concierge --classic
           # We need the kubectl (classic) snap because `kgoss` needs access to the /tmp directory
-          sudo concierge prepare -p microk8s --extra-snaps $EXTRA_SNAPS
+          sudo concierge prepare -p microk8s --extra-snaps "$EXTRA_SNAPS"
           sudo microk8s enable registry
           # FIXME: install via the goss snap when available
           goss_base_url="https://github.com/goss-org/goss/releases/latest/download"
@@ -61,7 +61,7 @@ jobs:
           for version in ${{ needs.changes.outputs.versions }}; do
             version_leaf_directory="${version##*/}"
 
-            cd "${version%/$version_leaf_directory}"
+            cd "${version%/"$version_leaf_directory"}"
 
             just pack "$version_leaf_directory"
             just test "$version_leaf_directory"

--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -8,6 +8,11 @@ on:
         default: 'rockcraft,just,kubectl'
         required: false
         type: string
+      rock-path:
+        description: "Path to the home directory of the rock we want to test"
+        default: "."
+        required: false
+        type: string
 
 
 jobs:
@@ -58,6 +63,7 @@ jobs:
           EXTRA_SNAPS: ${{ inputs.extra-snaps }}
       - name: Pack and test the rocks
         run: |
+          cd "${{ inputs.rock-path }}"
           for version in ${{ needs.changes.outputs.versions }}; do
             version_leaf_directory="${version##*/}"
             just pack "$version_leaf_directory"

--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -8,11 +8,6 @@ on:
         default: 'rockcraft,just,kubectl'
         required: false
         type: string
-      rock-path:
-        description: "Path to the rock we want to test. Defaults to the current working directory"
-        default: '.'
-        required: false
-        type: string
 
 
 jobs:
@@ -63,11 +58,11 @@ jobs:
           EXTRA_SNAPS: ${{ inputs.extra-snaps }}
       - name: Pack and test the rocks
         run: |
-          cd "${{ inputs.rock-path }}"
           for version in ${{ needs.changes.outputs.versions }}; do
-            just pack "$version"
-            just test "$version"
-            just clean "$version"
+            version_leaf_directory="${version##*/}"
+            just pack "$version_leaf_directory"
+            just test "$version_leaf_directory"
+            just clean "$version_leaf_directory"
           done
       - name: Open SSH session on failure
         if: ${{ failure() && (runner.debug == '1') }}


### PR DESCRIPTION
## Issue
We would like to use the `rock-pull-request.yaml` workflow to test the Temporal rocks.

1. The Temporal rocks repo is a monorepo (with all the Temporal rocks hosted in one repository). The `rock-pull-request` workflow assumes that the github repo hosts only one rock project.
2. The `rock-pull-request` installs a fixed set of snaps into the concierge env where the rock tests are executed. This is a limitation, as the Temporal rocks require some additional snaps installed that the `justfile` targets use.

## Solution
1. Adjust the workflows to work with version directories (output of `changes` job) of the form `1.23.1` as well as `temporal-server/1.23.1`. This former will ensure that observability rock repo tests continue to work, whereas the latter will ensure that the Temporal rocks monorepo is compatible with this workflow.
2. Add input `extra-snaps` which can be used to configure the snaps installed into the concierge env. Defaults to `rockcraft,just,kubectl`

## Testing
Test run in the Temporal rocks repo: https://github.com/canonical/temporal-rocks/actions/runs/15983452446/job/45131737223