### PR TITLE
feat: display juju debug-log in integration test runs

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -295,13 +295,15 @@ jobs:
 
       - name: Show logs
         run: | 
-          echo "$(pwd)"
           cd ${{ inputs.charm-path }}
           if test -d ./.logs; then
             for filename in ./.logs/*.txt; do
-                echo "::group::{{ $filename }}"
+                # begin collapsible log group for each file found in the folder; 
+                # this is github CI markup
+                # cfr: https://github.com/go-task/task/issues/647
+                printf "\n::group::{{ $filename }}\n"
                 cat "$filename"
-                echo "::endgroup::"
+                printf "\n::endgroup::\n"
             done
           else
             echo "${{ inputs.charm-path }}/.logs not found"
@@ -311,5 +313,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: juju-logs
-          path: ${{ inputs.charm-path }}/.logs
+          path: ${{ inputs.charm-path }}/.logs/
           # defaults to 'warn' on failure

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -7,6 +7,13 @@ on:
         type: string
         required: false
         default: .
+      log-path:
+        type: string
+        description: |
+          Path to a directory where the logs for an integration testing run will be stored.
+          Is always interpreted relative to the charm root.
+        required: false
+        default: .logs
       provider:
         type: string
         description: "The provider to choose for integration tests ('machine' or 'microk8s')"
@@ -292,12 +299,11 @@ jobs:
         with:
           timeout-minutes: 30
           limit-access-to-actor: true
-
       - name: Show logs
         run: | 
           cd ${{ inputs.charm-path }}
-          if test -d ./.logs; then
-            for filename in ./.logs/*.txt; do
+          if test -d ./${{ inputs.log-path }}; then
+            for filename in ./${{ inputs.log-path }}/*.txt; do
                 # begin collapsible log group for each file found in the folder; 
                 # this is github CI markup
                 # cfr: https://github.com/go-task/task/issues/647
@@ -306,14 +312,12 @@ jobs:
                 printf "\n::endgroup::\n"
             done
           else
-            echo "${{ inputs.charm-path }}/.logs not found"
+            echo "${{ inputs.charm-path }}/${{ inputs.log-path }} not found"
           fi
-
       - name: Upload logs
         uses: actions/upload-artifact@v4
-
         # defaults to 'warn' on failure
         with:
-          name: logs
+          name: charm-logs${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
           include-hidden-files: true
-          path: .logs/
+          path: ${{ inputs.log-path }}

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -301,7 +301,7 @@ jobs:
                 # begin collapsible log group for each file found in the folder; 
                 # this is github CI markup
                 # cfr: https://github.com/go-task/task/issues/647
-                printf "\n::group:: $filename\n"
+                printf '\n::group:: %s\n' "$filename"
                 cat "$filename"
                 printf "\n::endgroup::\n"
             done

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -306,7 +306,7 @@ jobs:
         id: log_path_det
         run: |
           # if the user gave us a relative path, interpret it from the charm-path root.
-          log_path=[[ "${{ inputs.log-path }}" =~ ^/ ]] && "${{ inputs.log-path }}" || "${{ inputs.charm-path }}/${{ inputs.log-path }}"
+          log_path=[[ "${{ inputs.log-path }}" =~ ^/ ]] && echo "${{ inputs.log-path }}" || echo "${{ inputs.charm-path }}/${{ inputs.log-path }}"
           echo "log_path=$log_path" >> "$GITHUB_OUTPUT"
       - name: Show logs
         run: | 

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -10,8 +10,11 @@ on:
       log-path:
         type: string
         description: |
-          Path to a directory where the logs for an integration testing run will be stored.
-          Is always interpreted relative to the charm root.
+          Path to a directory where the .txt logfiles for an integration testing run will be stored.
+          Relative and absolute file paths are both allowed. 
+          Relative paths are rooted against the charm repository root. 
+          Paths that begin with a wildcard character should be quoted to avoid being 
+          interpreted as YAML aliases.
         required: false
         default: .logs
       provider:
@@ -299,11 +302,16 @@ jobs:
         with:
           timeout-minutes: 30
           limit-access-to-actor: true
+      - name: Determine log files location
+        id: log_path_det
+        run: |
+          # if the user gave us a relative path, interpret it from the charm-path root.
+          log_path=[[ "${{ inputs.log-path }}" =~ ^/ ]] && "${{ inputs.log-path }}" || "${{ inputs.charm-path }}/${{ inputs.log-path }}"
+          echo "log_path=$log_path" >> "$GITHUB_OUTPUT"
       - name: Show logs
         run: | 
-          cd ${{ inputs.charm-path }}
-          if test -d ./${{ inputs.log-path }}; then
-            for filename in ./${{ inputs.log-path }}/*.txt; do
+          if test -d ${{ steps.log_path_det.outputs.log_path }}; then
+            for filename in ${{ steps.log_path_det.outputs.log_path }}/*.txt; do
                 # begin collapsible log group for each file found in the folder; 
                 # this is github CI markup
                 # cfr: https://github.com/go-task/task/issues/647
@@ -312,7 +320,7 @@ jobs:
                 printf "\n::endgroup::\n"
             done
           else
-            echo "${{ inputs.charm-path }}/${{ inputs.log-path }} not found"
+            echo "${{ steps.log_path_det.outputs.log_path }} not found"
           fi
       - name: Upload logs
         uses: actions/upload-artifact@v4
@@ -320,4 +328,4 @@ jobs:
         with:
           name: charm-logs${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
           include-hidden-files: true
-          path: ${{ inputs.log-path }}
+          path: ${{ steps.log_path_det.outputs.log_path }}

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -292,3 +292,24 @@ jobs:
         with:
           timeout-minutes: 30
           limit-access-to-actor: true
+
+      - name: Show juju debug-log
+        run: | 
+          if test -d ./.pytest_jubilant_jdl; then
+            for filename in ./.pytest_jubilant_jdl/*.txt; do
+                for ((i=0; i<=3; i++)); do
+                      echo "::group::{{ $filename }}"
+                      cat {{ $filename }}
+                      echo "::endgroup::"
+                done
+            done
+          else
+            echo "./.pytest_jubilant_jdl not found; ensure you're flying with `pytest-jubilant > 0.7`"
+          fi
+
+      - name: Upload juju debug-log
+        uses: actions/upload-artifact@v4
+        with:
+          name: juju-logs
+          path: ./.pytest_jubilant_jdl
+          # defaults to 'warn' on failure

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -303,15 +303,17 @@ jobs:
           timeout-minutes: 30
           limit-access-to-actor: true
       - name: Determine log files location
-        id: log_path_det
+        id: get_log_path
         run: |
           # if the user gave us a relative path, interpret it from the charm-path root.
+          # if path starts with / it's absolute, else it's relative, and we prepend the (absolute) charm-path to it
           log_path=[[ "${{ inputs.log-path }}" =~ ^/ ]] && echo "${{ inputs.log-path }}" || echo "${{ inputs.charm-path }}/${{ inputs.log-path }}"
+          echo "log path is: $log_path"
           echo "log_path=$log_path" >> "$GITHUB_OUTPUT"
       - name: Show logs
         run: | 
-          if test -d ${{ steps.log_path_det.outputs.log_path }}; then
-            for filename in ${{ steps.log_path_det.outputs.log_path }}/*.txt; do
+          if test -d "${{ steps.get_log_path.outputs.log_path }}"; then
+            for filename in ${{ steps.get_log_path.outputs.log_path }}/*.txt; do
                 # begin collapsible log group for each file found in the folder; 
                 # this is github CI markup
                 # cfr: https://github.com/go-task/task/issues/647
@@ -320,7 +322,7 @@ jobs:
                 printf "\n::endgroup::\n"
             done
           else
-            echo "${{ steps.log_path_det.outputs.log_path }} not found"
+            echo "${{ steps.get_log_path.outputs.log_path }} not found"
           fi
       - name: Upload logs
         uses: actions/upload-artifact@v4
@@ -328,4 +330,4 @@ jobs:
         with:
           name: charm-logs${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
           include-hidden-files: true
-          path: ${{ steps.log_path_det.outputs.log_path }}
+          path: ${{ steps.get_log_path.outputs.log_path }}

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -316,6 +316,6 @@ jobs:
         with:
           name: logs
           path: |
-            {{ inputs.charm-path }}/.logs/
-            {{ inputs.charm-path }}/.logs/logfile.txt
+            ${{ inputs.charm-path }}/.logs/
+            ${{ inputs.charm-path }}/.logs/logfile.txt
           # FIXME:remove this

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -296,10 +296,10 @@ jobs:
       - name: Show juju debug-log
         run: | 
           if test -d ./.pytest_jubilant_jdl; then
-            for filename in "./.pytest_jubilant_jdl/*.txt"; do
+            for filename in ./.pytest_jubilant_jdl/*.txt; do
                 for ((i=0; i<=3; i++)); do
                       echo "::group::{{ $filename }}"
-                      cat $filename
+                      cat "$filename"
                       echo "::endgroup::"
                 done
             done

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -316,6 +316,6 @@ jobs:
         with:
           name: logs
           path: |
+            .logs/
             ${{ inputs.charm-path }}/.logs/
-            ${{ inputs.charm-path }}/.logs/logfile.txt
           # FIXME:remove this

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -295,7 +295,7 @@ jobs:
 
       - name: Show logs
         run: | 
-          echo pwd
+          echo "$(pwd)"
           cd ${{ inputs.charm-path }}
           if test -d ./.logs; then
             for filename in ./.logs/*.txt; do

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -307,7 +307,7 @@ jobs:
         run: |
           # if the user gave us a relative path, interpret it from the charm-path root.
           # if path starts with / it's absolute, else it's relative, and we prepend the (absolute) charm-path to it
-          log_path=[[ "${{ inputs.log-path }}" =~ ^/ ]] && echo "${{ inputs.log-path }}" || echo "${{ inputs.charm-path }}/${{ inputs.log-path }}"
+          log_path="$([[ "${{ inputs.log-path }}" = /* ]] && echo "${{ inputs.log-path }}" || echo "${{ inputs.charm-path }}/${{ inputs.log-path }}")"
           echo "log path is: $log_path"
           echo "log_path=$log_path" >> "$GITHUB_OUTPUT"
       - name: Show logs

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -295,8 +295,8 @@ jobs:
 
       - name: Show juju debug-log
         run: | 
-          if test -d ./.pytest_jubilant_jdl; then
-            for filename in ./.pytest_jubilant_jdl/*.txt; do
+          if test -d ./.logs; then
+            for filename in ./.logs/*.txt; do
                 for ((i=0; i<=3; i++)); do
                       echo "::group::{{ $filename }}"
                       cat "$filename"
@@ -304,12 +304,12 @@ jobs:
                 done
             done
           else
-            echo "./.pytest_jubilant_jdl not found; ensure you're flying with pytest-jubilant > 0.7"
+            echo "./.logs not found; ensure you're flying with pytest-jubilant > 0.7"
           fi
 
       - name: Upload juju debug-log
         uses: actions/upload-artifact@v4
         with:
           name: juju-logs
-          path: ./.pytest_jubilant_jdl
+          path: ./.logs
           # defaults to 'warn' on failure

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -301,7 +301,7 @@ jobs:
                 # begin collapsible log group for each file found in the folder; 
                 # this is github CI markup
                 # cfr: https://github.com/go-task/task/issues/647
-                printf "\n::group::{{ $filename }}\n"
+                printf "\n::group:: $filename\n"
                 cat "$filename"
                 printf "\n::endgroup::\n"
             done
@@ -311,7 +311,11 @@ jobs:
 
       - name: Upload logs
         uses: actions/upload-artifact@v4
+
+        # defaults to 'warn' on failure
         with:
-          name: juju-logs
-          path: ${{ inputs.charm-path }}/.logs/
-          # defaults to 'warn' on failure
+          name: logs
+          path: |
+            {{ inputs.charm-path }}/.logs/
+            {{ inputs.charm-path }}/.logs/logfile.txt
+          # FIXME:remove this

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -293,7 +293,7 @@ jobs:
           timeout-minutes: 30
           limit-access-to-actor: true
 
-      - name: Show juju debug-log
+      - name: Show logs
         run: | 
           if test -d ./.logs; then
             for filename in ./.logs/*.txt; do
@@ -307,7 +307,7 @@ jobs:
             echo "./.logs not found; ensure you're flying with pytest-jubilant > 0.7"
           fi
 
-      - name: Upload juju debug-log
+      - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
           name: juju-logs

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -296,15 +296,15 @@ jobs:
       - name: Show juju debug-log
         run: | 
           if test -d ./.pytest_jubilant_jdl; then
-            for filename in ./.pytest_jubilant_jdl/*.txt; do
+            for filename in "./.pytest_jubilant_jdl/*.txt"; do
                 for ((i=0; i<=3; i++)); do
                       echo "::group::{{ $filename }}"
-                      cat {{ $filename }}
+                      cat $filename
                       echo "::endgroup::"
                 done
             done
           else
-            echo "./.pytest_jubilant_jdl not found; ensure you're flying with `pytest-jubilant > 0.7`"
+            echo "./.pytest_jubilant_jdl not found; ensure you're flying with pytest-jubilant > 0.7"
           fi
 
       - name: Upload juju debug-log

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -315,4 +315,5 @@ jobs:
         # defaults to 'warn' on failure
         with:
           name: logs
+          include-hidden-files: true
           path: .logs/

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -295,21 +295,20 @@ jobs:
 
       - name: Show logs
         run: | 
+          cd ${{ inputs.charm-path }}
           if test -d ./.logs; then
             for filename in ./.logs/*.txt; do
-                for ((i=0; i<=3; i++)); do
-                      echo "::group::{{ $filename }}"
-                      cat "$filename"
-                      echo "::endgroup::"
-                done
+                echo "::group::{{ $filename }}"
+                cat "$filename"
+                echo "::endgroup::"
             done
           else
-            echo "./.logs not found; ensure you're flying with pytest-jubilant > 0.7"
+            echo "${{ inputs.charm-path }}/.logs not found"
           fi
 
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
           name: juju-logs
-          path: ./.logs
+          path: ${{ inputs.charm-path }}/.logs
           # defaults to 'warn' on failure

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -315,7 +315,4 @@ jobs:
         # defaults to 'warn' on failure
         with:
           name: logs
-          path: |
-            .logs/
-            ${{ inputs.charm-path }}/.logs/
-          # FIXME:remove this
+          path: .logs/

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -295,6 +295,7 @@ jobs:
 
       - name: Show logs
         run: | 
+          echo pwd
           cd ${{ inputs.charm-path }}
           if test -d ./.logs; then
             for filename in ./.logs/*.txt; do

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -328,6 +328,7 @@ jobs:
         uses: actions/upload-artifact@v4
         # defaults to 'warn' on failure
         with:
-          name: charm-logs${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
+          name: charm-logs${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}-${{ matrix.suite }}
           include-hidden-files: true
+          # we assume that log_path is never going to be an empty string; but it may well be a non-existing directory.
           path: ${{ steps.get_log_path.outputs.log_path }}

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -10,7 +10,7 @@ on:
       log-path:
         type: string
         description: |
-          Path to a directory where the .txt logfiles for an integration testing run will be stored.
+          Path to a directory where the .txt log files for an integration testing run will be stored.
           Relative and absolute file paths are both allowed. 
           Relative paths are rooted against the charm repository root. 
           Paths that begin with a wildcard character should be quoted to avoid being 

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -284,6 +284,43 @@ jobs:
           CHARM_PATH="$(realpath "$charm_relative_path")"
           export CHARM_PATH
           uvx tox -e integration
+      - name: Determine log files location
+        if: always()
+        id: get_log_path
+        env:
+          LOG_PATH: ${{ inputs.log-path }}
+          CHARM_PATH: ${{ inputs.charm-path }}
+        run: |
+          # if the user gave us a relative path, interpret it from the charm-path root.
+          # if path starts with / it's absolute, else it's relative, and we prepend the (absolute) charm-path to it
+          case "$LOG_PATH" in
+            /*) log_path="$LOG_PATH" ;;
+            *) log_path="$CHARM_PATH/$LOG_PATH" ;;
+          esac
+          echo "log path is: $log_path"
+          echo "log_path=$log_path" >> "$GITHUB_OUTPUT"
+      - name: Show logs
+        if: always()
+        env:
+          LOG_DIR: ${{ steps.get_log_path.outputs.log_path }}
+        run: |
+          if test -d "$LOG_DIR"; then
+            shopt -s nullglob
+            for filename in "$LOG_DIR"/*.txt; do
+                printf '\n::group:: %s\n' "$filename"
+                cat "$filename"
+                printf "\n::endgroup::\n"
+            done
+          else
+            echo "$LOG_DIR not found"
+          fi
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: charm-logs${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
+          include-hidden-files: true
+          path: ${{ steps.get_log_path.outputs.log_path }}
 
   integration-matrix:
     name: Define Integration tests matrix
@@ -415,21 +452,29 @@ jobs:
           timeout-minutes: 30
           limit-access-to-actor: true
       - name: Determine log files location
+        if: always()
         id: get_log_path
+        env:
+          LOG_PATH: ${{ inputs.log-path }}
+          CHARM_PATH: ${{ inputs.charm-path }}
         run: |
           # if the user gave us a relative path, interpret it from the charm-path root.
           # if path starts with / it's absolute, else it's relative, and we prepend the (absolute) charm-path to it
-          case "${{ inputs.log-path }}" in
-            /*) log_path="${{ inputs.log-path }}" ;;
-            *) log_path="${{ inputs.charm-path }}/${{ inputs.log-path }}" ;;
+          case "$LOG_PATH" in
+            /*) log_path="$LOG_PATH" ;;
+            *) log_path="$CHARM_PATH/$LOG_PATH" ;;
           esac
           echo "log path is: $log_path"
           echo "log_path=$log_path" >> "$GITHUB_OUTPUT"
       - name: Show logs
-        run: | 
-          if test -d "${{ steps.get_log_path.outputs.log_path }}"; then
-            for filename in ${{ steps.get_log_path.outputs.log_path }}/*.txt; do
-                # begin collapsible log group for each file found in the folder; 
+        if: always()
+        env:
+          LOG_DIR: ${{ steps.get_log_path.outputs.log_path }}
+        run: |
+          if test -d "$LOG_DIR"; then
+            shopt -s nullglob
+            for filename in "$LOG_DIR"/*.txt; do
+                # begin collapsible log group for each file found in the folder;
                 # this is github CI markup
                 # cfr: https://github.com/go-task/task/issues/647
                 printf '\n::group:: %s\n' "$filename"
@@ -437,9 +482,10 @@ jobs:
                 printf "\n::endgroup::\n"
             done
           else
-            echo "${{ steps.get_log_path.outputs.log_path }} not found"
+            echo "$LOG_DIR not found"
           fi
       - name: Upload logs
+        if: always()
         uses: actions/upload-artifact@v4
         # defaults to 'warn' on failure
         with:

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -418,7 +418,10 @@ jobs:
         run: |
           # if the user gave us a relative path, interpret it from the charm-path root.
           # if path starts with / it's absolute, else it's relative, and we prepend the (absolute) charm-path to it
-          log_path="$([[ "${{ inputs.log-path }}" = /* ]] && echo "${{ inputs.log-path }}" || echo "${{ inputs.charm-path }}/${{ inputs.log-path }}")"
+          case "${{ inputs.log-path }}" in
+            /*) log_path="${{ inputs.log-path }}" ;;
+            *) log_path="${{ inputs.charm-path }}/${{ inputs.log-path }}" ;;
+          esac
           echo "log path is: $log_path"
           echo "log_path=$log_path" >> "$GITHUB_OUTPUT"
       - name: Show logs

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -11,9 +11,10 @@ on:
         type: string
         description: |
           Path to a directory where the .txt log files for an integration testing run will be stored.
-          Relative and absolute file paths are both allowed. 
-          Relative paths are rooted against the charm repository root. 
-          Paths that begin with a wildcard character should be quoted to avoid being 
+          Relative and absolute file paths are both allowed.
+          Relative paths are rooted against the charm directory specified by `charm-path`
+          (which defaults to the repository root, `.`).
+          Paths that begin with a wildcard character should be quoted to avoid being
           interpreted as YAML aliases.
         required: false
         default: .logs

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -8,6 +8,13 @@ on:
         default: '.'
         required: false
         type: string
+      log-path:
+        type: string
+        description: |
+          Path to a directory where the logs for an integration testing run will be stored.
+          Is always interpreted relative to the charm root.
+        required: false
+        default: .logs
       provider:
         description: "The provider to choose for either machine or k8s tests ('machine' or 'microk8s')"
         default: 'microk8s'
@@ -118,6 +125,7 @@ jobs:
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}
+      log-path: ${{ inputs.log-path }}
       provider: ${{ inputs.provider }}
       charmcraft-channel: ${{ inputs.charmcraft-channel }}
       juju-channel: ${{ inputs.juju-channel }}

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -11,8 +11,11 @@ on:
       log-path:
         type: string
         description: |
-          Path to a directory where the logs for an integration testing run will be stored.
-          Is always interpreted relative to the charm root.
+          Path to a directory where the .txt logfiles for an integration testing run will be stored.
+          Relative and absolute file paths are both allowed. 
+          Relative paths are rooted against the charm repository root. 
+          Paths that begin with a wildcard character should be quoted to avoid being 
+          interpreted as YAML aliases.
         required: false
         default: .logs
       provider:

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -13,7 +13,7 @@ on:
         description: |
           Path to a directory where the .txt logfiles for an integration testing run will be stored.
           Relative and absolute file paths are both allowed. 
-          Relative paths are rooted against the charm repository root. 
+          Relative paths are resolved relative to `charm-path`. 
           Paths that begin with a wildcard character should be quoted to avoid being 
           interpreted as YAML aliases.
         required: false

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -11,7 +11,7 @@ on:
       log-path:
         type: string
         description: |
-          Path to a directory where the .txt logfiles for an integration testing run will be stored.
+          Path to a directory where the .txt log files for an integration testing run will be stored.
           Relative and absolute file paths are both allowed. 
           Relative paths are resolved relative to `charm-path`. 
           Paths that begin with a wildcard character should be quoted to avoid being 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ block-beta
     qualitychecksslow["<b>Quality Checks (integration)</b>"]
     pack["Pack the charm"]
     integration["Integration tests"]
+    displaylogs["Display logs"]
+    uploadlogs["Upload logs zipfile"]
   end
 
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ block-beta
     integration["Integration tests"]
     displaylogs["Display logs"]
     uploadlogs["Upload logs zip file"]
+    integration --> displaylogs --> uploadlogs
   end
-
 
   block
     columns 1

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ block-beta
     pack["Pack the charm"]
     integration["Integration tests"]
     displaylogs["Display logs"]
-    uploadlogs["Upload logs zipfile"]
+    uploadlogs["Upload logs zip file"]
   end
 
 


### PR DESCRIPTION
Change to `_charm-quality-checks.yaml` (integration tests part) adding two steps:

for each file found in `./.logs`:
1. print to console
2. upload it as artifact

the idea is, we can put our juju debug-log output in there, and the CI will display them and upload as artifact.

Context: https://github.com/canonical/pytest-jubilant/pull/11

Tandem PR to demonstrate the workflow in action: https://github.com/canonical/o11y-tester-operator/actions/runs/16414197049