### PR TITLE
feat!: Central CI for TF

### DIFF
--- a/.github/workflows/_charm-terraform.yaml
+++ b/.github/workflows/_charm-terraform.yaml
@@ -1,0 +1,47 @@
+name: Terraform
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**/*.tf'
+
+jobs:
+  lint-terraform:
+    name: Terraform lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo snap install terraform --classic
+          sudo snap install just --classic
+      - name: Lint the Terraform modules
+        run: just lint-terraform
+  lint-terraform-docs:
+    name: Lint terraform docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo snap install terraform --classic
+          sudo snap install terraform-docs
+          sudo snap install just --classic
+      - name: Lint the Terraform docs
+        run: just lint-terraform-docs
+  validate-terraform:
+    name: Terraform validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo snap install terraform --classic
+          sudo snap install just --classic
+      - name: Validate the Terraform modules
+        run: just validate-terraform

--- a/.github/workflows/_charm-terraform.yaml
+++ b/.github/workflows/_charm-terraform.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint-terraform:
-    name: Terraform lint
+    name: Lint Terraform format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -22,7 +22,7 @@ jobs:
       - name: Lint the Terraform modules
         run: just lint-terraform
   lint-terraform-docs:
-    name: Lint terraform docs
+    name: Lint Terraform docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -46,3 +46,15 @@ jobs:
           sudo snap install just --classic
       - name: Validate the Terraform modules
         run: just validate-terraform
+  lint-terraform-endpoints:
+    name: Lint Terraform outputs.tf endpoints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo snap install terraform --classic
+          sudo snap install just --classic
+      - name: Lint the Terraform outputs.tf endpoints
+        run: just lint-terraform-endpoints

--- a/.github/workflows/_charm-terraform.yaml
+++ b/.github/workflows/_charm-terraform.yaml
@@ -1,6 +1,7 @@
 name: Terraform
 
 on:
+  workflow_call:
   pull_request:
     branches:
       - main

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -129,5 +129,5 @@ jobs:
     needs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
-    uses: canonical/observability/.github/workflows/_charm-terraform.yaml@latest # FIXME: use a tag when available
+    uses: canonical/observability/.github/workflows/_charm-terraform.yaml@feat/tf-ci # FIXME: use a tag when available
     secrets: inherit

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -124,3 +124,10 @@ jobs:
       parallelize-integration: ${{ inputs.parallelize-integration }}
       automatically-retry-hooks: ${{ inputs.automatically-retry-hooks }}
 
+  terraform-checks:
+    name: Terraform Quality Checks
+    needs:
+      - ci-ignore
+    if: needs.ci-ignore.outputs.any_modified == 'true'
+    uses: canonical/observability/.github/workflows/_charm-terraform.yaml@latest # FIXME: use a tag when available
+    secrets: inherit

--- a/justfile
+++ b/justfile
@@ -1,33 +1,19 @@
 set quiet  # Recipes are silent by default
 set export  # Just variables are exported to the environment
 
-terraform := `which terraform || which tofu || echo ""` # require 'terraform' or 'opentofu'
-
 [private]
 default:
   just --list
 
 # Lint everything
 [group("Lint")]
-lint: lint-terraform lint-workflows
+lint: lint-workflows
 
 # Format everything 
-[group("Format")]
-fmt: format-terraform
-
-# Lint the Terraform modules
-[group("Lint")]
-lint-terraform:
-  if [ -z "${terraform}" ]; then echo "ERROR: please install terraform or opentofu"; exit 1; fi
-  $terraform fmt -check -recursive -diff
+# [group("Format")]
+# fmt: format-terraform
 
 # Lint the Github workflows
 [group("Lint")]
 lint-workflows:
   uvx --from=actionlint-py actionlint
-
-# Format the Terraform modules
-[group("Format")]
-format-terraform:
-  if [ -z "${terraform}" ]; then echo "ERROR: please install terraform or opentofu"; exit 1; fi
-  $terraform fmt -recursive -diff


### PR DESCRIPTION
Fixes https://github.com/canonical/observability-stack/issues/39

Sample implementation:
- https://github.com/canonical/alertmanager-k8s-operator/pull/350

TODO:
- [ ] [Determine how to deduplicate](https://github.com/canonical/observability/blob/d5dd87e269baf7e7a3a8c44e7d1441945cab1bfd/.github/workflows/_charm-quality-checks.yaml#L120) the TF CI between `_charm-quality-checks.yaml` and `_charm_-terraform.yaml`
- [ ] Implement [recommendations](https://github.com/canonical/observability-team/issues/115)

> [!WARNING]
> If merged, this will make its way into the `v2` track tag, meaning that all charms repo PRs which have `.tf` file changes will need to conform to the Terraform CI standard. This includes having:
> 1. `justfile`
> 2. `.tfdocs-config.yml`
>
> Without this, PRs will need to be merged on failing TF CI, which is not blocking.

This PR also introduces a linting check which ensures that the `endpoints` in the `outputs.tf` file is up-to-date with the `charmcraft.yaml`. E.g. [In the alertmanager-k8s repo you can see we are already diverging](https://github.com/canonical/alertmanager-k8s-operator/actions/runs/16424092482/job/46409904066):

```bash
❯ just lint-tf-endpoints
service-mesh is missing from endpoints
require-cmr-mesh is missing from endpoints
provide-cmr-mesh is missing from endpoints
error: Recipe `lint-tf-endpoints` failed with exit code 1
```
