### PR TITLE
feat: parameterize Python version

### DIFF
--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -6,6 +6,9 @@ on:
       charm-path:
         type: string
         required: false
+      python-version:
+        type: string
+        default: "3.8"
 
 jobs:
   lint:
@@ -19,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ inputs.python-version }}
       - name: Install dependencies
         run: |
           python3 -m pip install tox

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -6,6 +6,9 @@ on:
       charm-path:
         type: string
         required: false
+      python-version:
+        type: string
+        default: "3.8"
 
 jobs:
   static:
@@ -19,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ inputs.python-version }}
       - name: Install dependencies
         run: |
           python3 -m pip install tox

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -6,6 +6,9 @@ on:
       charm-path:
         type: string
         required: false
+      python-version:
+        type: string
+        default: "3.8"
 
 jobs:
   unit-tests:
@@ -19,7 +22,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ inputs.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install tox

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -6,6 +6,9 @@ on:
       charm-path:
         type: string
         required: false
+      python-version:
+        type: string
+        default: "3.8"
 
 jobs:
   unit-tests:
@@ -19,7 +22,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ inputs.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install tox


### PR DESCRIPTION
To allow testing ops 3 which requires Python >=3.10 and also do not break testing on charms that are using ops 2