### PR TITLE
fix: change default runners input to json

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -18,7 +18,7 @@ on:
           Example: ["ubuntu-latest","Ubuntu_ARM64_4C_16G_03"]
         type: string
         required: false
-        default: "ubuntu-latest"
+        default: '["ubuntu-latest"]'
       charmcraft-channel:
         type: string
         required: true


### PR DESCRIPTION
This commit sets the default runners input value to a valid JSON string, which is what the rest of the workflow expects. This is needed because the default as it is will cause the following:

```
Error from function 'fromJSON': Unexpected symbol
```