### PR TITLE
fix: sed pattern to safely strip `.py` extension

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -186,7 +186,7 @@ jobs:
           if [[ $charm_name = "" ]]; then echo "Error: can't extract the charm name." && exit 1; fi
           # For each library belonging to the charm, publish it
           if [ -d "lib/charms/${charm_name}" ]; then
-            for lib in $(find "lib/charms/${charm_name}" -type f | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
+            for lib in $(find "lib/charms/${charm_name}" -type f | sed 's|lib/||' | sed 's/.py$//' | sed 's|/|.|g'); do
               result="$(charmcraft publish-lib "$lib")" || true
               # Filter out the succesfull publish-lib messages: https://github.com/canonical/charmcraft/issues/1981
               if [[ "$result" == *"sent to the store with version"* ]]; then


### PR DESCRIPTION
## Issue
The `release-libs` workflow tries to strip a `py` substring and it fails with the **py**roscope_coordinator_k8s/v0/profiling lib

## Solution
Add `$` to ensure that only the file extension is removed.

## Context
https://github.com/canonical/pyroscope-operators/actions/runs/16752187418/job/47426634777