### PR TITLE
feat: add optional coverage-omit input to charm-tiobe-scan workflow

### DIFF
--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -11,6 +11,11 @@ on:
         default: '.'
         required: false
         type: string
+      coverage-omit:
+        description: "Comma-separated glob pattern(s) for coverage.py --omit"
+        default: ''
+        required: false
+        type: string
 
 jobs:
   scan:
@@ -33,7 +38,12 @@ jobs:
 
       - name: Run tox tests to create coverage.xml
         run: |
-          tox -e unit && coverage xml -o cover/cobertura.xml
+          tox -e unit
+          OMIT_ARG=""
+          if [ -n "${{ inputs.coverage-omit }}" ]; then
+            OMIT_ARG="--omit=${{ inputs.coverage-omit }}"
+          fi
+          coverage xml -o cover/cobertura.xml $OMIT_ARG
 
       - name: Activate and prepare Python virtual environment
         env:


### PR DESCRIPTION
This change lets you exclude specific directories from the generated coverage.xml without having to fork or hack each charm repo’s CI.

What’s new?
  • A (optional)coverage-omit input (comma-separated globs) under workflow_call.inputs.
  • The coverage step now passes --omit=<your-globs> when coverage-omit is set.