### PR TITLE
fix: use noctua token in check libraries

### DIFF
--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -39,8 +39,10 @@ on:
         required: false
         type: boolean
     secrets:
-       CHARMHUB_TOKEN:
-         required: false
+      CHARMHUB_TOKEN:
+        required: false
+      OBSERVABILITY_NOCTUA_TOKEN:
+        required: true
 
 concurrency:
   group: ${{ github.ref }}${{ (inputs.charm-path && inputs.charm-path != '.') && format('-{0}', inputs.charm-path) || '' }}
@@ -96,7 +98,7 @@ jobs:
         run: sudo snap install charmcraft --classic --channel="$CHARMCRAFT_CHANNEL"
       - name: Check charm libraries
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
           CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
         run: |


### PR DESCRIPTION
Currently, the workflows uses its own token. This means than when external contributors run our CI (after we approve the run it), "Check Libraries" always fails.