### PR TITLE
feat: extend charm-tiobe-scan for other teams usage

### DIFF
--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -16,6 +16,11 @@ on:
         default: ""
         required: false
         type: string
+      coverage-folder:
+        description: "Folder under which the coverage xml report exists."
+        default: "cover"
+        required: false
+        type: string
 
 jobs:
   scan:
@@ -39,10 +44,11 @@ jobs:
       - name: Generate unittest coverage report
         env:
           CHARM_PATH: ${{ inputs.charm-path }}
+          COVERAGE_FOLDER: ${{ inputs.coverage-folder }}
         run: |
           base_wd="$(pwd)"
           cd "${CHARM_PATH}"
-          tox -e unit && coverage xml -o "${base_wd}/cover/cobertura.xml"
+          tox -e unit && coverage xml -o "${base_wd}/${COVERAGE_FOLDER}/cobertura.xml"
 
       - name: Activate and prepare Python virtual environment
         env:

--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -55,8 +55,14 @@ jobs:
           CHARM_PATH: ${{ inputs.charm-path }}
         run: |
           pushd "${CHARM_PATH}"
-          uv sync --extra=dev
-          source .venv/bin/activate
+          if [[ -f uv.lock ]]; then
+            uv sync --extra=dev
+            source .venv/bin/activate
+          else 
+             python -m venv .venv
+             source .venv/bin/activate
+             uv pip install -r requirements.txt
+          fi
           uv pip install pylint flake8
           echo "PATH=$PATH" >> "$GITHUB_ENV"
           popd


### PR DESCRIPTION
Different teams have different folders which tiobe expects the coverage to be in.

This PR introduces a new coverage folder input to make it customizable for other teams/repos.