### PR TITLE
feat: add interface test step to quality gates

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -33,6 +33,13 @@ on:
           Sets the `automatically-retry-hooks` in the model-defaults config.
         required: true
         type: boolean
+      strict-interface-tests:
+        description: |
+          Whether failing interface tests should error out the pipeline.
+        required: false
+        default: false  # opt-in FOR NOW
+        type: boolean
+
     secrets:
       CHARMHUB_TOKEN:
         required: false
@@ -161,6 +168,19 @@ jobs:
           sudo snap install astral-uv --classic
           cd "${{ inputs.charm-path }}"
           uvx tox -e unit
+
+  interface-test:
+    name: Interface tests
+    runs-on: ubuntu-latest
+    continue-on-error: "${{ inputs.strict-interface-tests }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Interface tests
+        run: |
+          sudo snap install astral-uv --classic
+          cd "${{ inputs.charm-path }}"
+          uvx tox -e interface
 
   pack-charm:
     name: Pack the charm

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -38,6 +38,12 @@ on:
         default: true
         required: false
         type: boolean
+      strict-interface-tests:
+        description: |
+          Whether failing interface tests should error out the pipeline.
+        required: false
+        default: false  # opt-in FOR NOW
+        type: boolean
     secrets:
       CHARMHUB_TOKEN:
         required: false
@@ -125,4 +131,5 @@ jobs:
       juju-channel: ${{ inputs.juju-channel }}
       parallelize-integration: ${{ inputs.parallelize-integration }}
       automatically-retry-hooks: ${{ inputs.automatically-retry-hooks }}
+      strict-interface-tests: ${{ inputs.strict-interface-tests }}
 


### PR DESCRIPTION
many of our charms have an `interface` tox env to run interface tests.
Those are technically unittests but not all charms have them and they tend to be more brittle hence the desire to not lump them together with other 'unit' tests. Also they're not quite 'unit'. Charmtech is in the process of modernizing the look and feel of interface tests and we (tracing team) want to start using them to gate our merges.

The idea is that if a charm supports interface tests, it will set
`strict-interface-tests: true` in its quality gates definition and this will tell the CI to run `tox -e interface` and fail the pipeline on failure. If left at its default `false` value, the pipeline won't block but the task will still show up as a failure.

Tandem PR:
https://github.com/canonical/pyroscope-k8s-operator/pull/249