### PR TITLE
fix: sed pattern to safely strip .py extension

### DIFF
--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -82,7 +82,7 @@ jobs:
           issue_body=""
           # For each library not belonging to the charm, check for a major version update
           #   "lib" would be of the form `charms.prometheus_k8s.v0.prometheus_scrape`
-          for lib in $(find "lib/charms/" -type f -name "*.py" | grep -v "$charm_name" | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
+          for lib in $(find "lib/charms/" -type f -name "*.py" | grep -v "$charm_name" | sed 's|lib/||' | sed 's/.py$//' | sed 's|/|.|g'); do
             # Extract the name of the library, the current major version, and the charm that owns it
             lib_name=$(cut -d. -f4 <<< "$lib")
             lib_major=$(cut -d. -f3 <<< "$lib")


### PR DESCRIPTION
## Issue
The update-libs workflow tries to strip a `py` substring and it fails with the **py**roscope_coordinator_k8s/v0/profiling lib

## Solution
Add `$` to ensure that only the file extension is removed.

