### PR TITLE
fix: coverage folder path for monorepos

### DIFF
--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           base_wd="$(pwd)"
           cd "${CHARM_PATH}"
-          tox -e unit && coverage xml -o "${base_wd}/${COVERAGE_FOLDER}/cobertura.xml"
+          tox -e unit && coverage xml -o "${base_wd}/${CHARM_PATH}/${COVERAGE_FOLDER}/cobertura.xml"
 
       - name: Activate and prepare Python virtual environment
         env:


### PR DESCRIPTION
## Issue
In a monorepo setup, multiple workflows run in parallel for different projects (charms). Currently, all workflows write their coverage XML files to the same location (i.e. `repo-root/cover/cobertura.xml`). This causes conflicts where coverage files can overwrite each other

## Solution
Update the coverage output path to include `CHARM_PATH`. This ensures that each charm’s workflow writes its coverage report into a dedicated folder, preventing collisions between parallel runs.