### PR TITLE
fix: Fixes extra-snaps param in run-tox-environment.yaml

### DIFF
--- a/.github/workflows/run-tox-environment.yaml
+++ b/.github/workflows/run-tox-environment.yaml
@@ -35,7 +35,7 @@ on:
         type: string
       extra-snaps:
         description: |
-          A space-separated list of snaps to be installed by the Concierge.
+          A comma-separated list of snaps to be installed by the Concierge, e.g. "snap_a,snap_b,snap_c"
         default: ""
         required: false
         type: string
@@ -51,7 +51,7 @@ jobs:
         if: ${{ inputs.prepare-host-env }}
         run: |
           sudo snap install concierge --classic
-          sudo concierge prepare -p ${{ inputs.provider }} --extra-snaps astral-uv ${{ inputs.extra-snaps }}
+          sudo concierge prepare -p ${{ inputs.provider }} --extra-snaps astral-uv,${{ inputs.extra-snaps }}
       - name: Run tox environment
         run: |
           cd "${{ inputs.tox-ini-path }}"


### PR DESCRIPTION
The `--extra-snaps` flag in concierge requires packages names to be separated by the comma not the space.