### PR TITLE
ci: add remote build

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -39,7 +39,7 @@ on:
       CHARMHUB_TOKEN:
         required: true
       LAUNCHPAD_TOKEN:
-        required: true
+        required: false
 
 permissions:
   contents: write

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -62,7 +62,7 @@ on:
       CHARMHUB_TOKEN:
         required: true
       LAUNCHPAD_TOKEN:
-        required: true
+        required: false
       
 
 concurrency:


### PR DESCRIPTION
Combines elements from #405 and adds a workflow input that a caller (from the Otelcol or GA charms) can set to indicate whether the charm release workflow should use local build or remote build. Most observability charm won't need to rely on remote build if they only need to be released for ARM and AMD. For Grafana Agent and Otelcol, we should rely on remote build since they need to also be released for S390x and PPC64EL.

## Changes
1. Adds a `pack-using-remote-build` input to `charm-release` and `_charm-release` that is false by default.
2. The caller will set `pack-using-remote-build` when calling `charm-release`. The value is propagated to `_charm-release`
3. The `_charm-release` WF is adjusted so if `pack-using-remote-build` is false, it locally packs the charm, similar to what it had done before. Otherwise, it remote builds it.


## Testing
PR https://github.com/canonical/o11y-tester-operator/pull/35 in the tester repo tests this workflow. It can test both scenraios (remote vs local build) by setting the `pack-using-remote-build` parameter when calling the `charm-release` workflow. When set to false, this workflow uses the AMD and ARM runners to release in parallel. Otherwise, it executes remote-build from the AMD runner.