### PR TITLE
fix: add tmate on release

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -178,3 +178,9 @@ jobs:
               --notes="$body" \
               --generate-notes
           done
+      - name: Open SSH session on failure
+        if: ${{ failure() && (runner.debug == '1') }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          timeout-minutes: 30
+          limit-access-to-actor: true


### PR DESCRIPTION
Adds tmate so we can ssh into the runner when release fails. Only works if the `Enable Debug Logging` option is set.