### PR TITLE
fix: pass charmcraft token correctly

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -173,7 +173,7 @@ jobs:
     permissions:
       contents: write
     secrets:
-      CHARMHUB_TOKEN: $ {{ secrets.CHARMHUB_TOKEN }}
+      CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
       LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
     with:
       release-channel: "${{ needs.define-matrix.outputs.release-channel }}"


### PR DESCRIPTION
There is a typo in the way `secrets.CHARMHUB_TOKEN` is passed from `charm-release` to `_charm-release`.