### PR TITLE
feat(ci): add automatic terraform tagging on charm release

### DIFF
--- a/.github/workflows/_charm-terraform-release.yaml
+++ b/.github/workflows/_charm-terraform-release.yaml
@@ -1,0 +1,68 @@
+name: Release Terraform module
+
+on:
+  workflow_call:
+    inputs:
+      terraform-tag-prefix:
+        description: "Tag prefix to use for the Terraform release tag."
+        default: 'tf-'
+        required: false
+        type: string
+      terraform-tag-suffix:
+        description: "Tag suffix to append to the Terraform release tag."
+        default: ''
+        required: false
+        type: string
+      charm-path:
+        description: "Path to the charm directory containing the terraform/ folder."
+        default: '.'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release the Terraform module
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for terraform changes
+        id: check-changes
+        working-directory: ${{ inputs.charm-path }}
+        run: |
+          # Check if the push includes changes to terraform/
+          if git diff --name-only HEAD~1..HEAD | grep -q '^terraform/'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create Terraform tag
+        if: steps.check-changes.outputs.changed == 'true'
+        working-directory: ${{ inputs.charm-path }}
+        env:
+          TAG_PREFIX: ${{ inputs.terraform-tag-prefix }}
+          TAG_SUFFIX: ${{ inputs.terraform-tag-suffix }}
+          GIT_BRANCH: ${{ github.ref_name }}
+        run: |
+          # Extract semantic version from the track branch name
+          track_version="${GIT_BRANCH#track/}"
+          # Calculate patch version: number of commits touching terraform/ since diverging from main
+          git fetch origin main
+          merge_base=$(git merge-base HEAD origin/main)
+          patch=$(git rev-list --count "$merge_base"..HEAD -- terraform/)
+          # Build the tag
+          tag="${TAG_PREFIX}${track_version}.${patch}${TAG_SUFFIX}"
+          echo "Creating tag: $tag"
+          # Configure git with noctua bot identity
+          git config --global user.email "webops+observability-noctua-bot@canonical.com"
+          git config --global user.name "Noctua"
+          # Create and push the annotated tag
+          git log -1 --pretty=%B > tag-message
+          git tag --annotate "$tag" --file=tag-message
+          rm -f tag-message
+          git push origin "$tag"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -248,4 +248,4 @@ jobs:
     with:
       terraform-tag-prefix: "${{ inputs.terraform-tag-prefix }}"
       terraform-tag-suffix: "${{ inputs.terraform-tag-suffix }}"
-      root-path: "${{ inputs.charm-path }}"
+      terraform-path: "${{ inputs.charm-path }}/terraform"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -242,10 +242,10 @@ jobs:
     needs:
       - release-charm
     if: github.ref_name != 'main' && startsWith(github.ref_name, 'track/')
-    uses: ./.github/workflows/_charm-terraform-release.yaml
+    uses: ./.github/workflows/terraform-release.yaml
     permissions:
       contents: write
     with:
       terraform-tag-prefix: "${{ inputs.terraform-tag-prefix }}"
       terraform-tag-suffix: "${{ inputs.terraform-tag-suffix }}"
-      charm-path: "${{ inputs.charm-path }}"
+      root-path: "${{ inputs.charm-path }}"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -64,6 +64,16 @@ on:
         default: false
         required: false
         type: boolean
+      terraform-tag-prefix:
+        description: "Tag prefix to use for the Terraform release tag."
+        default: 'tf-'
+        required: false
+        type: string
+      terraform-tag-suffix:
+        description: "Tag suffix to append to the Terraform release tag."
+        default: ''
+        required: false
+        type: string
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -226,3 +236,16 @@ jobs:
               fi
             done
           fi
+
+  release-terraform:
+    name: Release the Terraform module
+    needs:
+      - release-charm
+    if: github.ref_name != 'main' && startsWith(github.ref_name, 'track/')
+    uses: ./.github/workflows/_charm-terraform-release.yaml
+    permissions:
+      contents: write
+    with:
+      terraform-tag-prefix: "${{ inputs.terraform-tag-prefix }}"
+      terraform-tag-suffix: "${{ inputs.terraform-tag-suffix }}"
+      charm-path: "${{ inputs.charm-path }}"

--- a/.github/workflows/terraform-release.yaml
+++ b/.github/workflows/terraform-release.yaml
@@ -31,7 +31,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Validate branch format
+        id: validate-branch
+        env:
+          GIT_BRANCH: ${{ github.ref_name }}
+        run: |
+          # Only allow tagging on branches matching track/<major>.<minor>
+          if [[ "$GIT_BRANCH" =~ ^track/[0-9]+\.[0-9]+$ ]]; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Branch '$GIT_BRANCH' does not match track/<major>.<minor> format. Skipping."
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check for terraform changes
+        if: steps.validate-branch.outputs.valid == 'true'
         id: check-changes
         env:
           TERRAFORM_PATH: ${{ inputs.terraform-path }}
@@ -43,7 +56,7 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Create Terraform tag
-        if: steps.check-changes.outputs.changed == 'true'
+        if: steps.validate-branch.outputs.valid == 'true' && steps.check-changes.outputs.changed == 'true'
         env:
           TERRAFORM_PATH: ${{ inputs.terraform-path }}
           TAG_PREFIX: ${{ inputs.terraform-tag-prefix }}

--- a/.github/workflows/terraform-release.yaml
+++ b/.github/workflows/terraform-release.yaml
@@ -13,8 +13,8 @@ on:
         default: ''
         required: false
         type: string
-      charm-path:
-        description: "Path to the charm directory containing the terraform/ folder."
+      root-path:
+        description: "Path to the root directory containing the terraform/ folder."
         default: '.'
         required: false
         type: string
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - name: Check for terraform changes
         id: check-changes
-        working-directory: ${{ inputs.charm-path }}
+        working-directory: ${{ inputs.root-path }}
         run: |
           # Check if the push includes changes to terraform/
           if git diff --name-only HEAD~1..HEAD | grep -q '^terraform/'; then
@@ -43,7 +43,7 @@ jobs:
           fi
       - name: Create Terraform tag
         if: steps.check-changes.outputs.changed == 'true'
-        working-directory: ${{ inputs.charm-path }}
+        working-directory: ${{ inputs.root-path }}
         env:
           TAG_PREFIX: ${{ inputs.terraform-tag-prefix }}
           TAG_SUFFIX: ${{ inputs.terraform-tag-suffix }}

--- a/.github/workflows/terraform-release.yaml
+++ b/.github/workflows/terraform-release.yaml
@@ -13,9 +13,9 @@ on:
         default: ''
         required: false
         type: string
-      root-path:
-        description: "Path to the root directory containing the terraform/ folder."
-        default: '.'
+      terraform-path:
+        description: "Path to the terraform directory, relative to the repository root."
+        default: 'terraform'
         required: false
         type: string
 
@@ -33,28 +33,29 @@ jobs:
           fetch-depth: 0
       - name: Check for terraform changes
         id: check-changes
-        working-directory: ${{ inputs.root-path }}
+        env:
+          TERRAFORM_PATH: ${{ inputs.terraform-path }}
         run: |
-          # Check if the push includes changes to terraform/
-          if git diff --name-only HEAD~1..HEAD | grep -q '^terraform/'; then
+          # Check if the push includes changes to the terraform directory
+          if git diff --name-only HEAD~1..HEAD | grep -q "^${TERRAFORM_PATH}/"; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Create Terraform tag
         if: steps.check-changes.outputs.changed == 'true'
-        working-directory: ${{ inputs.root-path }}
         env:
+          TERRAFORM_PATH: ${{ inputs.terraform-path }}
           TAG_PREFIX: ${{ inputs.terraform-tag-prefix }}
           TAG_SUFFIX: ${{ inputs.terraform-tag-suffix }}
           GIT_BRANCH: ${{ github.ref_name }}
         run: |
           # Extract semantic version from the track branch name
           track_version="${GIT_BRANCH#track/}"
-          # Calculate patch version: number of commits touching terraform/ since diverging from main
+          # Calculate patch version: number of commits touching terraform dir since diverging from main
           git fetch origin main
           merge_base=$(git merge-base HEAD origin/main)
-          patch=$(git rev-list --count "$merge_base"..HEAD -- terraform/)
+          patch=$(git rev-list --count "$merge_base"..HEAD -- "$TERRAFORM_PATH/")
           # Build the tag
           tag="${TAG_PREFIX}${track_version}.${patch}${TAG_SUFFIX}"
           echo "Creating tag: $tag"


### PR DESCRIPTION
## Summary

Add automatic Terraform module tagging to the charm release pipeline. When a push to a `track/*` branch includes changes under the `terraform/` directory, a new annotated git tag is created and pushed.

The tag for a Terraform module on `track/major.minor` is built as:
```
{prefix}{major}.{minor}.{computed_patch}{suffix}
```
where `{computed_patch}` is the number of commits that touched the `terraform/` directory since the `track/` branch diverged from main.

## Changes

### New workflow: `terraform-release.yaml`
A **public** reusable workflow that can be called from `charm-release.yaml` or directly by repositories that have a Terraform module but no charm. It:
1. Detects whether the latest commit includes changes to `terraform/` (relative to `root-path`).
2. If changes are found, computes a semver tag: `<prefix><track_version>.<patch><suffix>`, where the patch number is the count of commits touching `terraform/` since diverging from `main`.
3. Creates and pushes an annotated git tag using the Noctua bot identity.

**Inputs:**
- `root-path` (default `"."`) — path to the root directory containing the `terraform/` folder.
- `terraform-tag-prefix` (default `"tf-"`) — prefix for the generated tag.
- `terraform-tag-suffix` (default `""`) — suffix for the generated tag.

### Updated workflow: `charm-release.yaml`
- Exposes `terraform-tag-prefix` and `terraform-tag-suffix` inputs.
- Adds a `release-terraform` job that runs after `release-charm`, only on `track/*` branches, passing through the root path and tag options.