### PR TITLE
chore: Update bases and versions in manifests; drop traefik

### DIFF
--- a/ssdlc-manifests/charm-sbom-manifest.yaml
+++ b/ssdlc-manifests/charm-sbom-manifest.yaml
@@ -48,7 +48,7 @@ artifacts:
 
   - name: grafana-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: opentelemetry-collector-k8s
@@ -83,22 +83,22 @@ artifacts:
 
   - name: prometheus-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: catalogue-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: cos-configuration-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: prometheus-scrape-config-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: blackbox-exporter-k8s
@@ -108,12 +108,7 @@ artifacts:
 
   - name: grafana-cloud-integrator
     channel: 2/edge
-    base: ubuntu@20.04
-    type: charm
-
-  - name: traefik-k8s
-    channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: grafana-agent
@@ -123,7 +118,7 @@ artifacts:
 
   - name: alertmanager-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: loki-coordinator-k8s
@@ -168,12 +163,12 @@ artifacts:
 
   - name: karma-alertmanager-proxy-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: prometheus-scrape-target-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: litmus-auth-k8s

--- a/ssdlc-manifests/charm-secscan-manifest.yaml
+++ b/ssdlc-manifests/charm-secscan-manifest.yaml
@@ -45,7 +45,7 @@ artifacts:
 
   - name: grafana-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: opentelemetry-collector-k8s
@@ -80,22 +80,22 @@ artifacts:
 
   - name: prometheus-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: catalogue-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: cos-configuration-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: prometheus-scrape-config-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: blackbox-exporter-k8s
@@ -105,12 +105,7 @@ artifacts:
 
   - name: grafana-cloud-integrator
     channel: 2/edge
-    base: ubuntu@20.04
-    type: charm
-
-  - name: traefik-k8s
-    channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: grafana-agent
@@ -120,7 +115,7 @@ artifacts:
 
   - name: alertmanager-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: loki-coordinator-k8s
@@ -165,12 +160,12 @@ artifacts:
 
   - name: karma-alertmanager-proxy-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: prometheus-scrape-target-k8s
     channel: 2/edge
-    base: ubuntu@20.04
+    base: ubuntu@24.04
     type: charm
 
   - name: litmus-auth-k8s

--- a/ssdlc-manifests/rock-sbom-manifest.yaml
+++ b/ssdlc-manifests/rock-sbom-manifest.yaml
@@ -83,11 +83,6 @@ artifacts:
     version: 0-24.04
     type: rock
 
-  - name: traefik-rock
-    image: ubuntu/traefik
-    version: 2-22.04
-    type: rock
-
   - name: loki-rock
     image: ubuntu/loki
     version: 3-24.04
@@ -100,40 +95,40 @@ artifacts:
 
   - name: litmuschaos-authserver-rock
     image: ubuntu/litmuschaos-authserver
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
 
   - name: litmuschaos-server-rock
     image: ubuntu/litmuschaos-server
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
   
   - name: litmuschaos-frontend-rock
     image: ubuntu/litmuschaos-frontend
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
 
   - name: litmuschaos-event-tracker-rock
     image: ubuntu/litmuschaos-event-tracker
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
 
   - name: litmuschaos-exporter-rock
     image: ubuntu/litmuschaos-exporter
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
   
   - name: litmuschaos-operator-rock
     image: ubuntu/litmuschaos-operator
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
 
   - name: litmuschaos-runner-rock
     image: ubuntu/litmuschaos-runner
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
   
   - name: litmuschaos-subscriber-rock
     image: ubuntu/litmuschaos-subscriber
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock

--- a/ssdlc-manifests/rock-secscan-manifest.yaml
+++ b/ssdlc-manifests/rock-secscan-manifest.yaml
@@ -80,11 +80,6 @@ artifacts:
     version: 0-24.04
     type: rock
 
-  - name: traefik-rock
-    image: ubuntu/traefik
-    version: 2-22.04
-    type: rock
-
   - name: loki-rock
     image: ubuntu/loki
     version: 3-24.04
@@ -97,40 +92,40 @@ artifacts:
 
   - name: litmuschaos-authserver-rock
     image: ubuntu/litmuschaos-authserver
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
 
   - name: litmuschaos-server-rock
     image: ubuntu/litmuschaos-server
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
   
   - name: litmuschaos-frontend-rock
     image: ubuntu/litmuschaos-frontend
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
 
   - name: litmuschaos-event-tracker-rock
     image: ubuntu/litmuschaos-event-tracker
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
 
   - name: litmuschaos-exporter-rock
     image: ubuntu/litmuschaos-exporter
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
   
   - name: litmuschaos-operator-rock
     image: ubuntu/litmuschaos-operator
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
 
   - name: litmuschaos-runner-rock
     image: ubuntu/litmuschaos-runner
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock
   
   - name: litmuschaos-subscriber-rock
     image: ubuntu/litmuschaos-subscriber
-    version: 3-24.04
+    version: 3-24.04_edge
     type: rock


### PR DESCRIPTION
Some of the charms now use different bases. Also, we don't own traefik anymore.