### PR TITLE
chore(ci): bump reusable workflows to v2

### DIFF
--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -124,7 +124,7 @@ jobs:
     needs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
-    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@main
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v2
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}


### PR DESCRIPTION
Update all `canonical/observability` reusable workflow references to use the `v2` tag.