### PR TITLE
feat(blueprints): add charms.just

### DIFF
--- a/.github/workflows/snap-update.yaml
+++ b/.github/workflows/snap-update.yaml
@@ -95,7 +95,7 @@ jobs:
           new_version="$(echo "$update_output" | grep '^new_version=' | cut -d= -f2)"
 
           # Check if any files were modified (not new folders, but modified files)
-          has_changes="$(git status --short -- . | grep -v '^??' | wc -l)"
+          has_changes="$(git status --short -- . | grep -cv '^??')"
           if [[ "$has_changes" -eq 0 ]]; then
             echo "No changes detected"
             new_version=""

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -6,6 +6,7 @@ Use a blueprint by copying the files into a new repository, then keep centralize
 
 ## Available blueprints
 
+- `charms`: Shared files and workflows for Observability charm repositories. See [charms/README.md](charms/README.md).
 - `rocks`: Shared files and workflows for Observability rock repositories. See [rocks/README.md](rocks/README.md).
 
 

--- a/blueprints/charms/.tfdocs.yaml
+++ b/blueprints/charms/.tfdocs.yaml
@@ -1,0 +1,41 @@
+# https://terraform-docs.io/user-guide/configuration/
+
+formatter: markdown table
+
+sections:
+  show:
+    - requirements
+    - modules
+    - providers
+    - inputs
+    - outputs
+
+# This allows us to customize the injected docs
+content: ""
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  # anchor: true
+  color: true
+  default: true
+  description: true
+  # escape: true
+  # hide-empty: false
+  # html: true
+  # indent: 2
+  lockfile: false
+  # read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/blueprints/charms/README.md
+++ b/blueprints/charms/README.md
@@ -1,0 +1,19 @@
+**Centralized:** `charms.just`
+**Dependencies:** `gh` | `just`
+
+This directory provides the shared baseline files used across Observability charm repositories.
+
+When bootstrapping a new charm, initialize it with the files from this folder so repositories stay consistent.
+
+## Structure
+
+```
+charm-name
+├── justfile      # Main justfile: imports 'charms.just' and allows for overrides
+├── README.md     # This README
+└── charms.just   # (*) Shared charm recipes
+```
+
+To refresh the centralized files, run `just refresh`.
+
+For project-specific customizations, see [../README.md#customization](../README.md#customization).

--- a/blueprints/charms/README.md
+++ b/blueprints/charms/README.md
@@ -10,10 +10,7 @@ When bootstrapping a new charm, initialize it with the files from this folder so
 ```
 charm-name
 ├── justfile      # Main justfile: imports 'charms.just' and allows for overrides
-├── README.md     # This README
 └── charms.just   # (*) Shared charm recipes
 ```
-
-To refresh the centralized files, run `just refresh`.
 
 For project-specific customizations, see [../README.md#customization](../README.md#customization).

--- a/blueprints/charms/charms.just
+++ b/blueprints/charms/charms.just
@@ -36,6 +36,8 @@ changelog ref:
         fi
     done < <(git log --format=%s "${base}..HEAD")
     # Print the commits in a Markdown changelog format
+    echo "# Changelog"
+    echo ""
     if [ -n "${breaking}" ]; then
         echo "## Breaking Changes"
         echo ""
@@ -66,6 +68,6 @@ refresh:
     api_path="repos/canonical/observability/contents/$refresh_folder"
     for file in charms.just; do
       echo "Fetching latest '$file' from canonical/observability ..."
-      gh api "$api_path/$file?ref=feat/charms-blueprints" --jq '.content' | base64 --decode > "$file"
+      gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
       echo "✓ $file updated"
     done

--- a/blueprints/charms/charms.just
+++ b/blueprints/charms/charms.just
@@ -1,12 +1,196 @@
 # Centralized justfile for the Canonical Observability charms
 set shell := ["bash", "-uc"]
 
+charm_name := `echo ${PWD##*/} | sed 's/-operator$//'`  # Get the charm name from the folder name
+
+export UV_FROZEN := "true"  # Prevent `uv run` from updating the lockfile
+export PYTHONPATH := ".:./lib:./src"
+
+
 [private]
-default:
+@default:
     just --list
 
+# Print the charm name
+[group("info")]
+@name:
+  echo "{{charm_name}}"
 
-# Find the merge-base between the current branch and `ref`, then print all commits since.
+
+# Update uv.lock dependencies
+[group("maintenance")]
+lock:
+    unset UV_FROZEN; uv lock --upgrade --no-cache
+
+# Scan for security vulnerabilities
+[group("maintenance")]
+scan:
+    @echo "Scanning for security vulnerabilities..."
+    uvx uv-secure
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+    #!/usr/bin/env bash
+    which -s gh || { echo "gh not found"; exit 1; }
+    refresh_folder="blueprints/charms"
+    api_path="repos/canonical/observability/contents/$refresh_folder"
+    for file in charms.just; do
+      echo "Fetching latest '$file' from canonical/observability ..."
+      gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
+      echo "✓ $file updated"
+    done
+
+
+# Format the codebase
+[group("dev")]
+format: sync
+    # Fix generic linting issues
+    uv run ruff check --fix-only
+    # Fix import-related issues (including ordering)
+    uv run ruff check --select=I --fix-only
+    # Format the code
+    uv run ruff format
+
+alias fmt := format
+
+# Lint the codebase
+[group("dev")]
+lint: sync
+    # Lint the code
+    uv run ruff check
+    # Run static checks
+    uv run ty check src
+    # Check for misspellings
+    uv run codespell src
+    # Check for dead code
+    uv run vulture src
+    # Run actionlint on GitHub Actions workflows
+    test -d .github/workflows && uvx --from=actionlint-py actionlint
+    @echo "✓ Linting passed!"
+
+
+# Run all quality checks: formatting, linting and unit tests
+[group("dev")]
+check: sync format lint unit
+    @echo; echo "✓ All checks passed!"
+
+# Sync the virtual environment (.venv)
+[private, group("dev")]
+sync:
+    uv sync --all-groups --all-extras
+
+# Sync and activate the virtual environment (.venv)
+[group("dev")]
+venv:
+    @echo "Activating virtual environment..."
+    @uv sync --all-groups --all-extras
+    @. .venv/bin/activate; exec "$SHELL" -i
+
+
+# Run unit tests
+[group("test")]
+unit *args: sync
+    uv run coverage run --source=src -m pytest tests/unit {{ args }}
+
+# Run integration tests
+[group("test")]
+integration *args: sync
+    uv run pytest --exitfirst tests/integration {{ args }}
+
+# Pretty print all feature files
+[group("info")]
+features:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    features_dir="tests/integration/features"
+    if [ ! -d "$features_dir" ]; then
+        echo "No features directory found at $features_dir"
+        exit 1
+    fi
+    # Calculate totals first
+    total_features=$(find "$features_dir" -name "*.feature" -type f | wc -l)
+    total_scenarios=$(grep -rh "^[[:space:]]*Scenario:" "$features_dir" 2>/dev/null | wc -l || echo "0")
+    printf "Total: \033[1m%d features\033[0m with \033[1m%d scenarios\033[0m\n" "$total_features" "$total_scenarios"
+    echo ""
+    for feature_file in "$features_dir"/*.feature; do
+        [ -f "$feature_file" ] || continue
+        filename=$(basename "$feature_file")
+        feature_name="${filename%.feature}"
+        # Extract the Feature: line
+        feature_title=$(grep -m1 "^Feature:" "$feature_file" | sed 's/Feature: //')
+        # Extract feature description (lines after Feature: until first Scenario, skipping blank lines)
+        description=$(awk '/^Feature:/{found=1; next} found && /^[[:space:]]*Scenario/{exit} found && /^[[:space:]]*$/{next} found{gsub(/^[[:space:]]+/, ""); print}' "$feature_file" | head -3)
+        # Count scenarios
+        scenario_count=$(grep -c "^[[:space:]]*Scenario:" "$feature_file" || echo "0")
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        printf "\033[1m%s\033[0m (%d scenarios)\n" "$feature_title" "$scenario_count"
+        echo "   $feature_file"
+        echo ""
+        if [ -n "$description" ]; then
+            echo "$description" | while IFS= read -r line; do
+                echo "   $line"
+            done
+            echo ""
+        fi
+        # List scenarios
+        grep "^[[:space:]]*Scenario:" "$feature_file" | sed 's/^[[:space:]]*Scenario:[[:space:]]*//' | while IFS= read -r scenario; do
+            echo "   - $scenario"
+        done
+        echo ""
+    done
+
+
+# Update the Terraform README with auto-generated content
+[group("terraform")]
+terraform-docs:
+    which terraform-docs > /dev/null 2>&1 || { echo "× terraform-docs not found"; exit 1; }
+    terraform-docs --config .tfdocs.yaml .
+    @echo "✓ Terraform docs updated"
+
+# Lint and validate the Terraform module
+[group("terraform")]
+terraform-lint:
+    which terraform > /dev/null 2>&1 || { echo "× terraform not found"; exit 1; }
+    cd terraform && terraform init -backend=false && terraform validate
+    terraform fmt -recursive -check
+    @echo "✓ Terraform lint passed"
+
+
+# Release a .charm file to Charmhub
+[group("release")]
+release charm_file channel:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Upload the charm and get the revision
+    echo "Uploading charm {{ charm_file }}..."
+    upload_output=$(charmcraft upload "{{ charm_file }}" --format=json)
+    charm_revision=$(echo "$upload_output" | jq -r '.revision')
+    echo "✓ Uploaded charm revision: $charm_revision"
+    # Get resources from charmcraft.yaml
+    resource_args=""
+    if [ -f charmcraft.yaml ]; then
+        while IFS= read -r resource_name; do
+            upstream=$(yq -r ".resources.\"$resource_name\".\"upstream-source\" // empty" charmcraft.yaml)
+            if [ -n "$upstream" ]; then
+                echo "Uploading resource '$resource_name' from $upstream..."
+                res_output=$(charmcraft upload-resource "{{ charm_name }}" "$resource_name" --image="docker://$upstream" --format=json)
+                res_revision=$(echo "$res_output" | jq -r '.revision')
+            else
+                echo "Fetching latest revision for resource '$resource_name'..."
+                res_revision=$(charmcraft resource-revisions "{{ charm_name }}" "$resource_name" --format=json | jq -r '.[0].revision')
+            fi
+            echo "✓ Resource '$resource_name' revision: $res_revision"
+            resource_args="$resource_args --resource=$resource_name:$res_revision"
+        done < <(yq -r '.resources | keys | .[]' charmcraft.yaml 2>/dev/null || true)
+    fi
+    # Release the charm
+    echo "Releasing {{ charm_name }} to {{ channel }}..."
+    # shellcheck disable=SC2086
+    charmcraft release "{{ charm_name }}" --revision="$charm_revision" --channel="{{ channel }}" $resource_args
+    echo "✓ Released {{ charm_name }} revision $charm_revision to {{ channel }}"
+
+# Print all commits between the current branch and the merge-base with `ref`
 [group("release")]
 [arg("ref", help="Branch (or generic ref) from to get the changelog from")]
 changelog ref:
@@ -59,15 +243,4 @@ changelog ref:
         echo "${others}"
     fi
 
-# Fetch centralized files from canonical/observability
-[group("maintenance")]
-refresh:
-    #!/usr/bin/env bash
-    which -s gh || { echo "gh not found"; exit 1; }
-    refresh_folder="blueprints/charms"
-    api_path="repos/canonical/observability/contents/$refresh_folder"
-    for file in charms.just; do
-      echo "Fetching latest '$file' from canonical/observability ..."
-      gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
-      echo "✓ $file updated"
-    done
+

--- a/blueprints/charms/charms.just
+++ b/blueprints/charms/charms.just
@@ -8,9 +8,9 @@ default:
 
 # Find the merge-base between the current branch and `ref`, then print all commits since.
 [group("release")]
+[arg("ref", help="Branch (or generic ref) from to get the changelog from")]
 changelog ref:
     #!/usr/bin/env bash
-    # We should only generate the changelog from the latest track/ branch
     set -euo pipefail
     resolved="{{ ref }}"
     if ! git rev-parse --verify "${resolved}" >/dev/null 2>&1; then

--- a/blueprints/charms/charms.just
+++ b/blueprints/charms/charms.just
@@ -76,7 +76,7 @@ check: sync format lint unit
     @echo; echo "✓ All checks passed!"
 
 # Sync the virtual environment (.venv)
-[private, group("dev")]
+[group("dev")]
 sync:
     uv sync --all-groups --all-extras
 

--- a/blueprints/charms/charms.just
+++ b/blueprints/charms/charms.just
@@ -1,0 +1,67 @@
+# Centralized justfile for the Canonical Observability charms
+set shell := ["bash", "-uc"]
+
+[private]
+default:
+    just --list
+
+
+# Find the merge-base between the current branch and `ref`, then print all commits since.
+[group("release")]
+changelog ref:
+    #!/usr/bin/env bash
+    # We should only generate the changelog from the latest track/ branch
+    set -euo pipefail
+    resolved="{{ ref }}"
+    if ! git rev-parse --verify "${resolved}" >/dev/null 2>&1; then
+        resolved="origin/{{ ref }}"
+    fi
+    base=$(git merge-base HEAD "${resolved}")
+    breaking=""
+    features=""
+    fixes=""
+    others=""
+    while IFS= read -r msg; do
+        if echo "${msg}" | grep -qE '^[a-z]+(\(.+\))?!:'; then
+            breaking="${breaking}- ${msg}"$'\n'
+        elif echo "${msg}" | grep -qE '^feat(\(.+\))?:'; then
+            features="${features}- ${msg}"$'\n'
+        elif echo "${msg}" | grep -qE '^fix(\(.+\))?:'; then
+            fixes="${fixes}- ${msg}"$'\n'
+        else
+            others="${others}- ${msg}"$'\n'
+        fi
+    done < <(git log --format=%s "${base}..HEAD")
+    if [ -n "${breaking}" ]; then
+        echo "## Breaking Changes"
+        echo ""
+        echo "${breaking}"
+    fi
+    if [ -n "${features}" ]; then
+        echo "## Features"
+        echo ""
+        echo "${features}"
+    fi
+    if [ -n "${fixes}" ]; then
+        echo "## Fixes"
+        echo ""
+        echo "${fixes}"
+    fi
+    if [ -n "${others}" ]; then
+        echo "## Others"
+        echo ""
+        echo "${others}"
+    fi
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+    #!/usr/bin/env bash
+    which -s gh || { echo "gh not found"; exit 1; }
+    refresh_folder="blueprints/charms"
+    api_path="repos/canonical/observability/contents/$refresh_folder"
+    for file in charms.just; do
+      echo "Fetching latest '$file' from canonical/observability ..."
+      gh api "$api_path/$file?ref=feat/charms-blueprints" --jq '.content' | base64 --decode > "$file"
+      echo "✓ $file updated"
+    done

--- a/blueprints/charms/charms.just
+++ b/blueprints/charms/charms.just
@@ -12,11 +12,14 @@ default:
 changelog ref:
     #!/usr/bin/env bash
     set -euo pipefail
+    # Sanitize the ref so that either a branch or a commit is valid
     resolved="{{ ref }}"
     if ! git rev-parse --verify "${resolved}" >/dev/null 2>&1; then
         resolved="origin/{{ ref }}"
     fi
+    # Find the merge-base 
     base=$(git merge-base HEAD "${resolved}")
+    # Parse all commit messages into a "conventional commits" category
     breaking=""
     features=""
     fixes=""
@@ -32,6 +35,7 @@ changelog ref:
             others="${others}- ${msg}"$'\n'
         fi
     done < <(git log --format=%s "${base}..HEAD")
+    # Print the commits in a Markdown changelog format
     if [ -n "${breaking}" ]; then
         echo "## Breaking Changes"
         echo ""

--- a/blueprints/charms/justfile
+++ b/blueprints/charms/justfile
@@ -1,0 +1,9 @@
+set allow-duplicate-recipes
+set allow-duplicate-variables
+import? 'charms.just'
+
+[private]
+@default:
+  just --list
+  echo ""
+  echo "For help with a specific recipe, run: just --usage <recipe>"

--- a/decision-records/2026-05-12--charm-changelog-management.md
+++ b/decision-records/2026-05-12--charm-changelog-management.md
@@ -1,0 +1,64 @@
+**Date:** 2026-05-12  
+**Author:** Luca Bello
+
+## Decision
+
+Each charm repository maintains a `CHANGELOG.md` file per track branch. The changelog documents changes relative to the previous track.
+
+### Branch structure
+
+| Branch | Changelog contains |
+|--------|-------------------|
+| `main` | Changes since the newest `track/X.Y` branch |
+| `track/4.0` | Changes since `track/3.0` |
+| `track/0.31` | Changes since `track/0.28` |
+| `track/X.Y` | Changes since the previous `track/` branch |
+
+### Workflow
+
+1. **During development on `main`**: Contributors add entries to `CHANGELOG.md` under an `## [Unreleased]` section as part of their PRs.
+
+2. **When cutting a new track branch** (e.g., `track/5.0` from `main`):
+   - The new `track/5.0` branch keeps the current `CHANGELOG.md` as-is (documenting changes since `track/4.0`).
+   - On `main`, reset `CHANGELOG.md` to a fresh template with only the `## [Unreleased]` header, since `main` now tracks changes relative to `track/5.0`.
+
+3. **Generating changelog content**: Use `just changelog <ref>` to generate a draft changelog from conventional commits between the current branch and a reference branch/commit. Review and edit the output before adding to `CHANGELOG.md`.
+
+### Changelog format
+
+```markdown
+# Changelog
+
+## [Unreleased]
+
+### Breaking Changes
+- description of breaking change
+
+### Features
+- description of new feature
+
+### Fixes
+- description of bug fix
+
+### Others
+- other notable changes (refactoring, docs, tests, etc.)
+```
+
+## Benefits
+
+- **Clear upgrade path**: Users can see what changed between tracks they're upgrading from/to.
+- **Track isolation**: Each track branch is self-contained with its own changelog history.
+- **Simple reset model**: When a new track branches off, `main` starts fresh, avoiding changelog merge conflicts.
+- **Automation-friendly**: The `just changelog` recipe provides a starting point from commit history.
+
+## Disadvantages
+
+- **Manual curation**: Generated changelogs need human review to be user-friendly.
+- **Reset discipline**: Maintainers must remember to reset `main`'s changelog when cutting a new track.
+- **Non-linear history**: If hotfixes are cherry-picked between tracks, they may appear in multiple changelogs.
+
+## Alternatives considered
+
+- **Single changelog across all branches**: Rejected because merge conflicts become unmanageable and it's unclear what version introduced which change.
+- **Tag-based changelogs only**: Rejected because tracks don't always align with tags, and we need visibility into unreleased changes.
+- **Automated changelog generation at release time**: Rejected because commit messages alone lack user-facing context; human curation produces better results.


### PR DESCRIPTION
## Summary

Adds the `charms` blueprint with shared justfile recipes for Observability charm repositories.

### New files

- **`blueprints/charms/charms.just`**: Centralized recipes for charms
  - `changelog <ref>`: Generate a changelog from conventional commits between current branch and a reference (outputs Markdown with Breaking Changes, Features, Fixes, Others sections)
  - `refresh`: Fetch the latest `charms.just` from canonical/observability
- **`blueprints/charms/justfile`**: Template justfile that imports `charms.just`
- **`blueprints/charms/README.md`**: Documentation for the blueprint

### ADR

- **`decision-records/2026-05-12--charm-changelog-management.md`**: Documents the changelog strategy for charm track branches (each track maintains a CHANGELOG.md relative to the previous track; `main` resets when a new track is cut)

### Other changes

- `blueprints/README.md`: Added charms to the list of available blueprints
- `.github/workflows/snap-update.yaml`: Fixed `grep | wc -l` to use `grep -c` instead