### PR TITLE
feat: add ci worfklows for snaps and spread.yaml

### DIFF
--- a/.github/workflows/snap-pull-request.yaml
+++ b/.github/workflows/snap-pull-request.yaml
@@ -1,0 +1,24 @@
+name: Pull Request
+
+on:
+  workflow_call:
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo snap install concierge --classic
+          sudo concierge prepare -p crafts --extra-snaps=just,yq
+      - name: Run tests
+        run: snapcraft test
+      - name: Open SSH session on failure
+        if: ${{ failure() && (runner.debug == '1') }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          timeout-minutes: 30
+          limit-access-to-actor: true

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -1,0 +1,37 @@
+name: Release Snap
+
+on:
+  workflow_call:
+    secrets:
+      # Snapcraft Store credentials for uploading and releasing snaps.
+      # Generate at https://snapcraft.io/docs/registering-your-app
+      # Export with: snapcraft export-login --snaps=<snap-name> --channels=<channels> -
+      SNAPCRAFT_STORE_CREDENTIALS:
+        required: true
+      # Launchpad credential token, needed by `snapcraft remote-build`.
+      # See https://launchpad.net/+apidoc for token generation.
+      LAUNCHPAD_TOKEN:
+        required: true
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo snap install concierge --classic
+          sudo concierge prepare -p crafts --extra-snaps=just,yq
+      - name: Build and release snap
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          SNAPCRAFT_LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
+        run: just release
+      - name: Open SSH session on failure
+        if: ${{ failure() && (runner.debug == '1') }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          timeout-minutes: 30
+          limit-access-to-actor: true

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -7,6 +7,7 @@ Use a blueprint by copying the files into a new repository, then keep centralize
 ## Available blueprints
 
 - `rocks`: Shared files and workflows for Observability rock repositories. See [rocks/README.md](rocks/README.md).
+- `snaps`: Shared files and workflows for Observability snap repositories. See [snaps/README.md](snaps/README.md).
 
 
 ## Customization

--- a/blueprints/snaps/README.md
+++ b/blueprints/snaps/README.md
@@ -1,0 +1,30 @@
+**Centralized:** `snaps.just` | `spread.yaml`
+**Dependencies:** `gh` | `snapcraft` | `just`
+
+This directory provides the shared baseline files used across Observability snap repositories.
+
+When bootstrapping a new snap, initialize it with the files from this folder so repositories stay consistent.
+
+## Structure
+
+```
+snap-name
+├── justfile        # Main justfile: imports 'snaps.just' and allows for overrides
+├── snaps.just      # (*) Shared snap recipes
+├── spread.yaml     # (*) Shared spread configuration
+└── snapcraft.yaml  # Snap definition at the repository root
+```
+
+## Branching & Channels
+
+The release channel is derived from the current git branch:
+
+| Branch | Channel |
+|--------|---------|
+| `main` | `latest/edge` |
+| `track/X.Y` | `X.Y/edge` |
+| `<other>` | `latest/edge/<other>` |
+
+To refresh the centralized files, run `just refresh`.
+
+For project-specific customizations, see [../README.md#customization](../README.md#customization).

--- a/blueprints/snaps/justfile
+++ b/blueprints/snaps/justfile
@@ -1,0 +1,9 @@
+set allow-duplicate-recipes
+set allow-duplicate-variables
+import? 'snaps.just'
+
+[private]
+@default:
+  just --list
+  echo ""
+  echo "For help with a specific recipe, run: just --usage <recipe>"

--- a/blueprints/snaps/snaps.just
+++ b/blueprints/snaps/snaps.just
@@ -1,0 +1,58 @@
+# Centralized justfile for the Canonical Observability snaps
+set shell := ["bash", "-uc"]
+
+snap_name := `echo ${PWD##*/} | sed 's/-snap$//'`  # Get the snap name from the folder name
+all_architectures := `yq -r '[.platforms | keys[] ] | join(",")' snap/snapcraft.yaml`
+# Derive the release channel from the current branch:
+#   main          -> latest/edge
+#   track/X.Y     -> X.Y/edge
+#   other         -> latest/edge/<branch>
+branch := `git rev-parse --abbrev-ref HEAD`
+channel := if branch == "main" { "latest/edge" } else if branch =~ '^track/.*' { replace_regex(branch, "^track/", "") + "/edge" } else { "latest/edge/" + branch }
+
+[private]
+@default:
+  just --list
+  echo "{{snap_name}}"
+  echo "For help with a specific recipe, run: just --usage <recipe>"
+
+# Print the snap name
+[group("info")]
+@name:
+  echo "{{snap_name}}"
+
+# Print the current branch and release channel
+[group("info")]
+@channel:
+  echo "branch: {{branch}} → channel: {{channel}}"
+
+# Remote-build, upload and release a snap to the Snap Store
+[group("release")]
+release build_for=all_architectures:
+  #!/usr/bin/env bash
+  set -e
+  echo "Starting remote build for architecture(s): {{build_for}} ..."
+  snapcraft remote-build --build-for="{{build_for}}"
+  snap_files=(*.snap)
+  if [[ ${#snap_files[@]} -eq 0 || ! -e "${snap_files[0]}" ]]; then
+    echo "× Error: no snap files found after remote build."
+    exit 1
+  fi
+  for snap_file in "${snap_files[@]}"; do
+    echo "Uploading and releasing $snap_file to {{channel}} ..."
+    snapcraft upload "$snap_file" --release="{{channel}}"
+    echo "✓ {{snap_name}} ($snap_file) released to {{channel}}"
+  done
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+  #!/usr/bin/env bash
+  which -s gh || { echo "gh not found"; exit 1; }
+  refresh_folder="blueprints/snaps"
+  api_path="repos/canonical/observability/contents/$refresh_folder"
+  for file in snaps.just spread.yaml; do
+    echo "Fetching latest '$file' from canonical/observability ..."
+    gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
+    echo "✓ $file updated"
+  done

--- a/blueprints/snaps/spread.yaml
+++ b/blueprints/snaps/spread.yaml
@@ -1,4 +1,4 @@
-project: snap
+project: opentelemetry-collector
 
 backends:
   craft:

--- a/blueprints/snaps/spread.yaml
+++ b/blueprints/snaps/spread.yaml
@@ -1,0 +1,13 @@
+project: opentelemetry-collector
+
+backends:
+  craft:
+    type: craft
+    allocate: "false"
+    systems:
+      - ubuntu-24.04:
+
+suites:
+  tests/spread/integration/:
+    summary: Integration tests for the snap
+    kill_timeout: 20m

--- a/blueprints/snaps/spread.yaml
+++ b/blueprints/snaps/spread.yaml
@@ -1,4 +1,4 @@
-project: opentelemetry-collector
+project: snap
 
 backends:
   craft:

--- a/snaps.just
+++ b/snaps.just
@@ -1,0 +1,58 @@
+# Centralized justfile for the Canonical Observability snaps
+set shell := ["bash", "-uc"]
+
+snap_name := `echo ${PWD##*/} | sed 's/-snap$//'`  # Get the snap name from the folder name
+all_architectures := `yq -r '[.platforms | keys[] ] | join(",")' snap/snapcraft.yaml`
+# Derive the release channel from the current branch:
+#   main          -> latest/edge
+#   track/X.Y     -> X.Y/edge
+#   other         -> latest/edge/<branch>
+branch := `git rev-parse --abbrev-ref HEAD`
+channel := if branch == "main" { "latest/edge" } else if branch =~ '^track/.*' { replace_regex(branch, "^track/", "") + "/edge" } else { "latest/edge/" + branch }
+
+[private]
+@default:
+  just --list
+  echo "{{snap_name}}"
+  echo "For help with a specific recipe, run: just --usage <recipe>"
+
+# Print the snap name
+[group("info")]
+@name:
+  echo "{{snap_name}}"
+
+# Print the current branch and release channel
+[group("info")]
+@channel:
+  echo "branch: {{branch}} → channel: {{channel}}"
+
+# Remote-build, upload and release a snap to the Snap Store
+[group("release")]
+release build_for=all_architectures:
+  #!/usr/bin/env bash
+  set -e
+  echo "Starting remote build for architecture(s): {{build_for}} ..."
+  snapcraft remote-build --build-for="{{build_for}}"
+  snap_files=(*.snap)
+  if [[ ${#snap_files[@]} -eq 0 || ! -e "${snap_files[0]}" ]]; then
+    echo "× Error: no snap files found after remote build."
+    exit 1
+  fi
+  for snap_file in "${snap_files[@]}"; do
+    echo "Uploading and releasing $snap_file to {{channel}} ..."
+    snapcraft upload "$snap_file" --release="{{channel}}"
+    echo "✓ {{snap_name}} ($snap_file) released to {{channel}}"
+  done
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+  #!/usr/bin/env bash
+  which -s gh || { echo "gh not found"; exit 1; }
+  refresh_folder="blueprints/snaps"
+  api_path="repos/canonical/observability/contents/$refresh_folder"
+  for file in snaps.just; do
+    echo "Fetching latest '$file' from canonical/observability ..."
+    gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
+    echo "✓ $file updated"
+  done


### PR DESCRIPTION
## Summary

Add reusable GitHub Actions workflows and blueprint updates for snaps:

### New workflows
- **`snap-pull-request.yaml`** — Installs dependencies via concierge, runs `snapcraft test`. Includes debug helpers (disk utilization, tmate SSH on failure).
- **`snap-release.yaml`** — Installs dependencies via concierge, runs `just release` (remote-build + upload to Snap Store). Requires `SNAPCRAFT_STORE_CREDENTIALS` and `LAUNCHPAD_TOKEN` secrets.

### Blueprint updates
- Added `spread.yaml` to the snaps blueprint (centralized test configuration, matching the rocks pattern).
- Updated `snaps.just` `refresh` recipe to sync `spread.yaml` alongside `snaps.just`.
- Updated `blueprints/snaps/README.md` to reflect the new file.