### PR TITLE
feat(snaps): switch to folder-based versioning and add update workflow

### DIFF
--- a/.github/workflows/snap-pull-request.yaml
+++ b/.github/workflows/snap-pull-request.yaml
@@ -4,9 +4,38 @@ on:
   workflow_call:
 
 jobs:
+  changes:
+    name: Determine modified snaps
+    runs-on: ubuntu-24.04
+    outputs:
+      versions: ${{ steps.changed-versions.outputs.versions }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Find snapcraft.yaml changes
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: "**/snapcraft.yaml"
+      - name: Extract the versions
+        id: changed-versions
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          versions=""
+          for file in $CHANGED_FILES; do
+            version="$(echo "$file" | cut -d'/' -f1)"
+            versions="$versions $version"
+          done
+          versions="$(echo "$versions" | xargs -n1 | sort -uV | xargs)"
+          echo "versions=$versions"
+          echo "versions=$versions" >> "$GITHUB_OUTPUT"
+
   tests:
     name: Tests
     runs-on: ubuntu-24.04
+    needs: [changes]
+    if: needs.changes.outputs.versions != ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -14,8 +43,17 @@ jobs:
         run: |
           sudo snap install concierge --classic
           sudo concierge prepare -p crafts --extra-snaps=just,yq
+      - name: Print disk utilization
+        if: ${{ (runner.debug == '1') }}
+        run: df -h
       - name: Run tests
-        run: snapcraft test
+        run: |
+          for version in ${{ needs.changes.outputs.versions }}; do
+            echo "Testing snap version $version ..."
+            cd "$version"
+            snapcraft test
+            cd ..
+          done
       - name: Open SSH session on failure
         if: ${{ failure() && (runner.debug == '1') }}
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -14,9 +14,48 @@ on:
         required: true
 
 jobs:
-  release:
-    name: Release
+  changes:
+    name: Determine modified snaps
     runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Find snapcraft.yaml changes
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: "**/snapcraft.yaml"
+      - name: Build release matrix from changed versions and platforms
+        id: build-matrix
+        run: |
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          matrix='{"include":[]}'
+          for file in $CHANGED_FILES; do
+            # Extract the version folder (e.g. "1.2" from "1.2/snap/snapcraft.yaml")
+            version="$(echo "$file" | cut -d'/' -f1)"
+            # Parse platforms from the snapcraft.yaml
+            platforms="$(yq -r '.platforms | keys | .[]' "$file")"
+            for platform in $platforms; do
+              matrix="$(echo "$matrix" | jq -c --arg v "$version" --arg p "$platform" '.include += [{"version": $v, "platform": $p}]')"
+            done
+          done
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+
+  release:
+    name: Release ${{ matrix.version }} (${{ matrix.platform }})
+    runs-on: ubuntu-24.04
+    needs: [changes]
+    if: ${{ fromJSON(needs.changes.outputs.matrix).include[0] != null }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,7 +67,7 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
           SNAPCRAFT_LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
-        run: just release
+        run: just release ${{ matrix.version }} ${{ matrix.platform }}
       - name: Open SSH session on failure
         if: ${{ failure() && (runner.debug == '1') }}
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/snap-update.yaml
+++ b/.github/workflows/snap-update.yaml
@@ -1,0 +1,109 @@
+name: Update Snap on new releases of its source
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+    inputs:
+      source-repo:
+        description: "Repository of the source application in 'org/repo' form"
+        required: true
+        type: string
+      commit-username:
+        description: "The username to use for committing the updates"
+        default: 'Noctua'
+        required: false
+        type: string
+      commit-email:
+        description: "The email address to use for committing the updates"
+        default: 'webops+observability-noctua-bot@canonical.com'
+        required: false
+        type: string
+
+    secrets:
+      OBSERVABILITY_NOCTUA_TOKEN:
+        required: true
+      NOCTUA_GPG_PASSPHRASE:
+        required: true
+      NOCTUA_GPG_PRIVATE:
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge-pr:
+    name: Merge previous green PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Merge any pre-existing PRs from the automatically generated "chore/add-version" branch if the CI is green
+        run: |
+          # If a PR from "chore/add-version" is open and CI checks are passing, merge it
+          is_pr_open="$(gh pr list --head chore/add-version --state open --json id --jq 'length')"
+          if [[ "$is_pr_open" == "1" ]]; then
+            if gh pr checks chore/add-version; then
+              echo "CI checks are passing, merging the chore/add-version PR"
+              gh pr merge chore/add-version --admin --squash --delete-branch
+            else
+              echo "CI checks are not passing for the existing chore/add-version PR, adding a comment."
+              gh pr comment chore/add-version --body "This PR cannot be automatically merged because CI checks are not passing. Please check the CI results, resolve any issues, and merge the PR manually."
+            fi
+          elif [[ "$is_pr_open" != "0" ]]; then
+            # The number of open PRs should always be either 0 or 1
+            echo "There's two PRs from the same branch; this should never happen!"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
+  update:
+    name: Update the snap for new upstream releases
+    runs-on: ubuntu-latest
+    needs:
+      - merge-pr
+    steps:
+      - name: Checkout the snap source
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo snap install just --classic
+          sudo snap install jq
+          sudo snap install yq
+      - name: Check for new upstream releases and create the snap if needed
+        id: check-and-update
+        env:
+          GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
+        run: |
+          just update ${{ inputs.source-repo }}
+          new_version="$(git status --short | grep '^??' | awk '{print $2}' | sed 's@/$@@')"
+          echo "snap_name=$(just name)" >> "$GITHUB_OUTPUT"
+          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+
+      - name: Import and configure the GPG key for Noctua
+        if: steps.check-and-update.outputs.new_version != ''
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.NOCTUA_GPG_PRIVATE }}
+          passphrase: ${{ secrets.NOCTUA_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Create a PR
+        if: steps.check-and-update.outputs.new_version != ''
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
+          commit-message: "chore(deps): bump ${{ steps.check-and-update.outputs.snap_name }} version to ${{ steps.check-and-update.outputs.new_version }}"
+          committer: "${{ inputs.commit-username }} <${{ inputs.commit-email }}>"
+          author: "${{ inputs.commit-username }} <${{ inputs.commit-email }}>"
+          title: "chore: add snap for ${{ steps.check-and-update.outputs.snap_name }} ${{ steps.check-and-update.outputs.new_version }}"
+          body: Automated update to follow upstream [release](https://github.com/${{ inputs.source-repo }}/releases/tag/${{ steps.check-and-update.outputs.new_version }}) of ${{ steps.check-and-update.outputs.snap_name }}.
+          branch: "chore/add-version"
+          delete-branch: true

--- a/blueprints/snaps/README.md
+++ b/blueprints/snaps/README.md
@@ -12,18 +12,19 @@ snap-name
 ├── justfile        # Main justfile: imports 'snaps.just' and allows for overrides
 ├── snaps.just      # (*) Shared snap recipes
 ├── spread.yaml     # (*) Shared spread configuration
-└── snapcraft.yaml  # Snap definition at the repository root
+└── X.Y/            # One folder per major.minor version
+    └── snap/
+        └── snapcraft.yaml
 ```
 
-## Branching & Channels
+## Versioning & Channels
 
-The release channel is derived from the current git branch:
+Each snap version lives in its own `X.Y` folder. The release channel is derived from the folder name:
 
-| Branch | Channel |
-|--------|---------|
-| `main` | `latest/edge` |
-| `track/X.Y` | `X.Y/edge` |
-| `<other>` | `latest/edge/<other>` |
+| Version folder | Channel(s) |
+|----------------|------------|
+| Latest `X.Y`   | `X.Y/edge` + `latest/edge` |
+| Older `X.Y`    | `X.Y/edge` |
 
 To refresh the centralized files, run `just refresh`.
 

--- a/blueprints/snaps/snaps.just
+++ b/blueprints/snaps/snaps.just
@@ -20,6 +20,16 @@ latest_version := `find . -name snapcraft.yaml -printf '%h\n' | sed 's@./@@; s@/
 @latest-version:
   echo "{{latest_version}}"
 
+# Pack a snap locally for a specific version and architecture
+[group("dev")]
+pack version=latest_version build_for="amd64":
+  cd "{{version}}" && snapcraft pack --build-for="{{build_for}}"
+
+# Promote a snap from one channel to another
+[group("release")]
+promote version=latest_version from_channel="" to_channel="":
+  cd "{{version}}" && snapcraft promote {{snap_name}} --from-channel="{{from_channel}}" --to-channel="{{to_channel}}" --yes
+
 # Remote-build, upload and release a snap to the Snap Store
 [group("release")]
 release version=latest_version build_for="amd64":

--- a/blueprints/snaps/snaps.just
+++ b/blueprints/snaps/snaps.just
@@ -59,16 +59,11 @@ release version=latest_version build_for="amd64":
 # Generate a snap for the latest version of the upstream project
 [arg("source_repo", help="Repository of the upstream project in 'org/repo' form")]
 [group("maintenance")]
-update source_repo release_tag="":
+update source_repo:
   #!/usr/bin/env bash
   set -e
-  if [[ -z "{{release_tag}}" ]]; then
-    latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
-    echo "Latest release for {{source_repo}} is $latest_release"
-  else
-    latest_release="{{release_tag}}"
-    echo "Release version manually set to $latest_release"
-  fi
+  latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
+  echo "Latest release for {{source_repo}} is $latest_release"
   version="${latest_release}"
   version="${version#v}"  # Strip generic v- prefix
   # Use only major.minor for the folder name
@@ -81,7 +76,7 @@ update source_repo release_tag="":
   if [[ -d "$version" ]]; then echo "Folder $version already exists, nothing to do" && exit 0; fi
   # Create the folder for the new version and update the snapcraft.yaml
   cp -r "{{latest_version}}" "$version"
-  latest_release="$latest_release" version="$version" yq -i \
+  version="$version" yq -i \
     '.version = strenv(version)' \
     "./$version/snap/snapcraft.yaml"
   echo "✓ Created snap for version $version"

--- a/blueprints/snaps/snaps.just
+++ b/blueprints/snaps/snaps.just
@@ -2,13 +2,7 @@
 set shell := ["bash", "-uc"]
 
 snap_name := `echo ${PWD##*/} | sed 's/-snap$//'`  # Get the snap name from the folder name
-all_architectures := `yq -r '[.platforms | keys[] ] | join(",")' snap/snapcraft.yaml`
-# Derive the release channel from the current branch:
-#   main          -> latest/edge
-#   track/X.Y     -> X.Y/edge
-#   other         -> latest/edge/<branch>
-branch := `git rev-parse --abbrev-ref HEAD`
-channel := if branch == "main" { "latest/edge" } else if branch =~ '^track/.*' { replace_regex(branch, "^track/", "") + "/edge" } else { "latest/edge/" + branch }
+latest_version := `find . -name snapcraft.yaml -printf '%h\n' | sed 's@./@@; s@/snap@@' | sort -V | tail -n1`
 
 [private]
 @default:
@@ -21,28 +15,66 @@ channel := if branch == "main" { "latest/edge" } else if branch =~ '^track/.*' {
 @name:
   echo "{{snap_name}}"
 
-# Print the current branch and release channel
+# Print the latest snap version
 [group("info")]
-@channel:
-  echo "branch: {{branch}} → channel: {{channel}}"
+@latest-version:
+  echo "{{latest_version}}"
 
 # Remote-build, upload and release a snap to the Snap Store
 [group("release")]
-release build_for=all_architectures:
+release version=latest_version build_for="amd64":
   #!/usr/bin/env bash
   set -e
-  echo "Starting remote build for architecture(s): {{build_for}} ..."
+  channel="{{version}}/edge"
+  # snapcraft remote-build requires a git repository to be present
+  git init
+  echo "Starting remote build for {{snap_name}} {{version}} ({{build_for}}) ..."
+  cd "{{version}}"
   snapcraft remote-build --build-for="{{build_for}}"
   snap_files=(*.snap)
   if [[ ${#snap_files[@]} -eq 0 || ! -e "${snap_files[0]}" ]]; then
     echo "× Error: no snap files found after remote build."
     exit 1
   fi
+  channels="$channel"
+  if [[ "{{version}}" == "{{latest_version}}" ]]; then
+    channels="$channel,latest/edge"
+  fi
   for snap_file in "${snap_files[@]}"; do
-    echo "Uploading and releasing $snap_file to {{channel}} ..."
-    snapcraft upload "$snap_file" --release="{{channel}}"
-    echo "✓ {{snap_name}} ($snap_file) released to {{channel}}"
+    echo "Uploading and releasing $snap_file to $channels ..."
+    snapcraft upload "$snap_file" --release="$channels"
+    echo "✓ {{snap_name}} ($snap_file) released to $channels"
   done
+
+# Generate a snap for the latest version of the upstream project
+[arg("source_repo", help="Repository of the upstream project in 'org/repo' form")]
+[group("maintenance")]
+update source_repo release_tag="":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "{{release_tag}}" ]]; then
+    latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
+    echo "Latest release for {{source_repo}} is $latest_release"
+  else
+    latest_release="{{release_tag}}"
+    echo "Release version manually set to $latest_release"
+  fi
+  version="${latest_release}"
+  version="${version#v}"  # Strip generic v- prefix
+  # Use only major.minor for the folder name
+  version="$(echo "$version" | grep -oP '^\d+\.\d+')"
+  if [[ -z "$version" ]]; then
+    echo "× Error: could not parse major.minor version from '$latest_release'"
+    exit 1
+  fi
+  # If the version already exists, exit here
+  if [[ -d "$version" ]]; then echo "Folder $version already exists, nothing to do" && exit 0; fi
+  # Create the folder for the new version and update the snapcraft.yaml
+  cp -r "{{latest_version}}" "$version"
+  latest_release="$latest_release" version="$version" yq -i \
+    '.version = strenv(version)' \
+    "./$version/snap/snapcraft.yaml"
+  echo "✓ Created snap for version $version"
 
 # Fetch centralized files from canonical/observability
 [group("maintenance")]

--- a/blueprints/snaps/snaps.just
+++ b/blueprints/snaps/snaps.just
@@ -20,15 +20,32 @@ latest_version := `find . -name snapcraft.yaml -printf '%h\n' | sed 's@./@@; s@/
 @latest-version:
   echo "{{latest_version}}"
 
+# Print comma-separated list of platforms from snapcraft.yaml
+[group("info")]
+@platforms version=latest_version:
+  yq -r '[.platforms | keys[]] | join(",")' "{{version}}/snap/snapcraft.yaml"
+
 # Pack a snap locally for a specific version and architecture
 [group("dev")]
 pack version=latest_version build_for="amd64":
   cd "{{version}}" && snapcraft pack --build-for="{{build_for}}"
 
-# Promote a snap from one channel to another
+# Promote a snap to the next risk level (edge→beta→candidate→stable)
 [group("release")]
-promote version=latest_version from_channel="" to_channel="":
-  cd "{{version}}" && snapcraft promote {{snap_name}} --from-channel="{{from_channel}}" --to-channel="{{to_channel}}" --yes
+promote version=latest_version from_risk="edge":
+  #!/usr/bin/env bash
+  set -e
+  case "{{from_risk}}" in
+    edge)      to_risk="beta" ;;
+    beta)      to_risk="candidate" ;;
+    candidate) to_risk="stable" ;;
+    *) echo "× Error: invalid risk '{{from_risk}}'. Must be one of: edge, beta, candidate." && exit 1 ;;
+  esac
+  from_channel="{{version}}/${from_risk}"
+  to_channel="{{version}}/${to_risk}"
+  echo "Promoting {{snap_name}} from $from_channel → $to_channel ..."
+  snapcraft promote {{snap_name}} --from-channel="$from_channel" --to-channel="$to_channel" --yes
+  echo "✓ {{snap_name}} promoted to $to_channel"
 
 # Remote-build, upload and release a snap to the Snap Store
 [group("release")]


### PR DESCRIPTION
## Summary

Overhaul the snap blueprint to align with the rocks blueprint patterns:

### Changes

- **Folder-based versioning**: Snap versions now live in `X.Y/snap/snapcraft.yaml` folders instead of using git branches (`track/X.Y`). Channel is derived from the folder name (`X.Y/edge`); the latest version also publishes to `latest/edge`.

- **`snaps.just` rewrite**:
  - `release` recipe now takes `version` and `build_for` (single arch) parameters, runs `git init` before `snapcraft remote-build` (required for remote-build to work in CI), and uploads to the appropriate channel(s).
  - New `update` recipe: detects latest upstream release via `gh`, creates a new version folder from the previous one, and updates `snapcraft.yaml`.
  - New `latest-version` info recipe.

- **`snap-release.yaml` rewrite**: Detects which `snapcraft.yaml` files changed, parses their platforms, and builds a matrix that spins up one runner per architecture calling `just release <version> <arch>`.

- **New `snap-update.yaml` workflow**: Modeled on `rock-update.yaml` — merges previous green auto-PRs, runs `just update`, GPG-signs, and opens a PR via `peter-evans/create-pull-request`.

- **README update**: Documents the new folder structure and channel derivation.