### PR TITLE
fix: properly propagate permissions to _charm-codeql-analysis

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -119,5 +119,12 @@ jobs:
       - linting
       - unit-test
     uses: canonical/observability/.github/workflows/_charm-codeql-analysis.yml@v0
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
     with:
       charm-path: "${{ inputs.charm-path }}"

--- a/.github/workflows/bundle-pull-request.yaml
+++ b/.github/workflows/bundle-pull-request.yaml
@@ -69,6 +69,13 @@ jobs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
     uses: canonical/observability/.github/workflows/_charm-codeql-analysis.yml@v0
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
     with:
       charm-path: "${{ inputs.bundle-path }}"
 

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -82,6 +82,13 @@ jobs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
     uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v0
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -101,6 +101,13 @@ jobs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
     uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v0
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
     secrets:
       CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
     with:


### PR DESCRIPTION
The change is needed with orgs/repos calling the workflows with Workflow permissions = Read repository contents and packages permissions