### PR TITLE
fix: Remove the juju model-defaults in quality checks

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -221,15 +221,12 @@ jobs:
           case "$PROVIDER" in
             machine)
               sudo -E concierge prepare -p machine
-              juju model-defaults -c lxd automatically-retry-hooks=${{ inputs.automatically-retry-hooks }}
               ;;
             microk8s)
               sudo -E concierge prepare -p microk8s
-              juju model-defaults -c microk8s automatically-retry-hooks=${{ inputs.automatically-retry-hooks }}
               ;;
             k8s)
               sudo -E concierge prepare -p k8s
-              juju model-defaults -c k8s automatically-retry-hooks=${{ inputs.automatically-retry-hooks }}
               ;;
           esac
       - name: Download charm artifact
@@ -291,15 +288,12 @@ jobs:
           case "$PROVIDER" in
             machine)
               sudo -E concierge prepare -p machine
-              juju model-defaults -c lxd automatically-retry-hooks=${{ inputs.automatically-retry-hooks }}
               ;;
             microk8s)
               sudo -E concierge prepare -p microk8s
-              juju model-defaults -c microk8s automatically-retry-hooks=${{ inputs.automatically-retry-hooks }}
               ;;
             k8s)
               sudo -E concierge prepare -p k8s
-              juju model-defaults -c k8s automatically-retry-hooks=${{ inputs.automatically-retry-hooks }}
               ;;
           esac
       # FIXME: Remove the below step when runners are configurable. See https://github.com/canonical/observability/issues/408.

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -124,7 +124,7 @@ jobs:
     needs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
-    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v2
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@fix/remove-juju-default-qualit-checks
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}


### PR DESCRIPTION
Remove the juju model-defaults in quality checks workflow due to broken concierge usage. This PR might be the proper fix:
- https://github.com/canonical/observability/pull/452