### PR TITLE
fix: properly add write permission to upload to charmhub

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -136,6 +136,8 @@ jobs:
   release-to-charmhub:
     name: Release to CharmHub
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     needs:
       - build
     strategy:
@@ -171,6 +173,8 @@ jobs:
     name: Release arm64 to CharmHub
     # needs to be run on arm or the oci image will resolve to the amd64 one.
     runs-on: Ubuntu_ARM64_4C_16G_03
+    permissions:
+      contents: write
     needs:
       - build-arm
     strategy:

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -122,6 +122,8 @@ jobs:
     needs:
       - quality-checks
     uses: canonical/observability/.github/workflows/_charm-release.yaml@v0
+    permissions:
+      contents: write
     secrets:
       CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
     with:


### PR DESCRIPTION
To avoid the current error:

```
/usr/bin/sudo snap install charmcraft --classic --channel 3.x/candidate
charmcraft (3.x/candidate) 3.5.3 from Canonical** installed
/snap/bin/charmcraft upload --format json --release 3.7/edge maas-region_ubuntu@24.04-arm64.charm
Starting to push 'maas-region_ubuntu@24.04-arm64.charm'
Uploading... (--->)
Uploading... (<---)
Uploading bytes ended, id d5c0523f-2ded-4199-b2f6-75dfde83212d
Upload d5c0523f-2ded-4199-b2f6-75dfde83212d started, got status url /v1/charm/maas-region/revisions/review?upload-id=d5c0523f-2ded-4199-b2f6-75dfde83212d
Status checked: {'revisions': [{'errors': None, 'revision': None, 'status': 'new', 'upload-id': 'd5c0523f-2ded-4199-b2f6-75dfde83212d'}]}
Status checked: {'revisions': [{'errors': None, 'revision': None, 'status': 'new', 'upload-id': 'd5c0523f-2ded-4199-b2f6-75dfde83212d'}]}
Status checked: {'revisions': [{'errors': None, 'revision': 356, 'status': 'scanned', 'upload-id': 'd5c0523f-2ded-4199-b2f6-75dfde83212d'}]}
Status checked: {'revisions': [{'errors': None, 'revision': 356, 'status': 'approved', 'upload-id': 'd5c0523f-2ded-4199-b2f6-75dfde83212d'}]}
{
    "revision": 356
}
Error: Resource not accessible by integration
Error: HttpError: Resource not accessible by integration
    at /home/runner/work/_actions/canonical/charming-actions/2.5.0-rc/dist/upload-charm/index.js:10328:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
/usr/bin/sudo test -d /root/snap/charmcraft/common/cache/charmcraft/log
No charmcraft logs generated, skipping artifact upload.
```