### PR TITLE
feat(v1): dynamic multi-arch runner matrix for rock tests

### DIFF
--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -10,9 +10,12 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       versions: ${{ steps.changed-versions.outputs.versions }}
+      runners: ${{ steps.changed-versions.outputs.runners }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install yq
+        run: sudo snap install yq
       - name: Find rockcraft.yaml changes
         id: changed-files
         uses: tj-actions/changed-files@v46
@@ -28,11 +31,28 @@ jobs:
           echo "versions=$versions"
           echo "versions=$versions" >> "$GITHUB_OUTPUT"
 
+          # build runner list from the union of platforms across all changed rocks
+          declare -A runner_set
+          for version in $versions; do
+            while IFS= read -r platform; do
+              case "$platform" in
+                amd64) runner_set["ubuntu-24.04"]=1 ;;
+                arm64) runner_set["ubuntu-24.04-arm"]=1 ;;
+              esac
+            done < <(yq '.platforms | keys | .[]' "${version}/rockcraft.yaml")
+          done
+          runners=$(printf '%s\n' "${!runner_set[@]}" | jq -R . | jq -sc .)
+          echo "runners=$runners"
+          echo "runners=$runners" >> "$GITHUB_OUTPUT"
+
   tests:
-    name: Tests
-    runs-on: ubuntu-24.04
+    name: Tests (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
     needs: [changes]
     if: needs.changes.outputs.versions != ''
+    strategy:
+      matrix:
+        runner: ${{ fromJSON(needs.changes.outputs.runners) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -44,7 +64,7 @@ jobs:
           sudo microk8s enable registry
           # FIXME: install via the goss snap when available
           goss_base_url="https://github.com/goss-org/goss/releases/latest/download"
-          curl -L ${goss_base_url}/goss-linux-amd64 -o /usr/local/bin/goss
+          curl -L ${goss_base_url}/goss-linux-$(dpkg --print-architecture) -o /usr/local/bin/goss
           chmod +rx /usr/local/bin/goss
           curl -L ${goss_base_url}/kgoss -o /usr/local/bin/kgoss
           chmod +rx /usr/local/bin/kgoss
@@ -61,7 +81,12 @@ jobs:
         run: df -h
       - name: Pack and test the rocks
         run: |
+          arch="$(dpkg --print-architecture)"
           for version in ${{ needs.changes.outputs.versions }}; do
+            if ! yq -e ".platforms | has(\"$arch\")" "$version/rockcraft.yaml" > /dev/null 2>&1; then
+              echo "skipping $version: no $arch platform declared"
+              continue
+            fi
             just pack "$version"
             just test "$version"
             just clean "$version"


### PR DESCRIPTION
i've made a pr to the [airflow-rock](https://github.com/canonical/airflow-rocks) which uses [rock-pull-request.yaml](https://github.com/lczyk/observability/blob/main/.github/workflows/rock-pull-request.yaml) to enable arm64 builds but it could not get tested in the CI since this workflow does not support multiarch tests. now it does

passing workflow example: https://github.com/canonical/airflow-rocks/actions/runs/26900186194/job/79350219139?pr=26

^ with a temp hotpatch in the [airflow-rocks](https://github.com/canonical/airflow-rocks/pull/26) PR

<img width="1194" height="121" alt="recent" src="https://github.com/user-attachments/assets/9caf22f8-8274-4f37-a7b4-2e8fb923d022" />
