### PR TITLE
fix: properly add labels when checking libs

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -61,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check-secret
+    permissions:
+      issues: write
     if: needs.check-secret.outputs.defined == 'true'
     steps:
       - name: Checkout

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -89,6 +89,9 @@ jobs:
       # only required for workflows in private repositories
       actions: read
       contents: read
+
+      # for adding labels to PRs from checking libraries workflow
+      issues: write
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -108,6 +108,9 @@ jobs:
       # only required for workflows in private repositories
       actions: read
       contents: read
+
+      # for adding labels to PRs from checking libraries workflow
+      issues: write
     secrets:
       CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
     with:


### PR DESCRIPTION
Currently failing with:

```
Library charms.data_platform_libs.v0.data_interfaces was already up to date in version 0.58.
Library charms.data_platform_libs.v0.s3 was already up to date in version 0.6.
Library charms.grafana_agent.v0.cos_agent was already up to date in version 0.25.
Library charms.haproxy.v1.haproxy_route_tcp was already up to date in version 1.4.
Library charms.maas_site_manager_k8s.v0.enroll was already up to date in version 0.2.
Library charms.operator_libs_linux.v2.snap was already up to date in version 2.15.
Library charms.rolling_ops.v0.rollingops was already up to date in version 0.9.
Library charms.tempo_coordinator_k8s.v0.charm_tracing was already up to date in version 0.12.
Library charms.tempo_coordinator_k8s.v0.tracing was already up to date in version 0.11.
Error: Resource not accessible by integration
Error: HttpError: Resource not accessible by integration
    at /home/runner/work/_actions/canonical/charming-actions/2.5.0-rc/dist/check-libraries/index.js:10328:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

because by default, the check-libraries action is adding labels:

```
2026-06-08T09:46:12.2392962Z ##[group]Run canonical/charming-actions/check-libraries@2.5.0-rc
2026-06-08T09:46:12.2394504Z with:
2026-06-08T09:46:12.2447738Z   credentials: ***
2026-06-08T09:46:12.2460088Z   github-token: ***
2026-06-08T09:46:12.2461039Z   charm-path: maas-region
2026-06-08T09:46:12.2462081Z   charmcraft-channel: latest/stable
2026-06-08T09:46:12.2463196Z   use-labels: true
2026-06-08T09:46:12.2464128Z   label-success: Libraries: OK
2026-06-08T09:46:12.2465868Z   label-fail: Libraries: Out of sync
2026-06-08T09:46:12.2467577Z   comment-on-pr: false
2026-06-08T09:46:12.2469199Z   fail-build: false
```