### PR TITLE
fix(ci): handle grep exit code in snap-update workflow

### DIFF
--- a/.github/workflows/snap-update.yaml
+++ b/.github/workflows/snap-update.yaml
@@ -91,7 +91,8 @@ jobs:
           new_version="$(echo "$update_output" | grep '^new_version=' | cut -d= -f2)"
 
           # Check if any files were modified (not new folders, but modified files)
-          has_changes="$(git status --short -- . | grep -cv '^??')"
+          # Note: grep -c returns exit code 1 when count is 0, so we need || true
+          has_changes="$(git status --short -- . | grep -cv '^??' || true)"
           if [[ "$has_changes" -eq 0 ]]; then
             echo "No changes detected"
             new_version=""


### PR DESCRIPTION
When the snap update workflow runs and there are no changes, `grep -cv '^??'` returns exit code 1 because grep exits non-zero when it finds zero matches. This causes the workflow step to fail even though no-changes is a valid outcome.

Add `|| true` to prevent the exit code from propagating.

Fixes: https://github.com/canonical/grafana-agent-snap/actions/runs/27128408845/job/80063027049