### PR TITLE
chore: bump for node 24

### DIFF
--- a/.github/workflows/_charm-codeql-analysis.yml
+++ b/.github/workflows/_charm-codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Setup Python

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -72,7 +72,7 @@ jobs:
     if: needs.check-secret.outputs.defined == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Check charm libraries # Make sure our charm libraries are updated

--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -41,7 +41,7 @@ jobs:
       charms: ${{ steps.builder.outputs.charms }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Setup LXD
@@ -81,7 +81,7 @@ jobs:
       charms: ${{ steps.builder.outputs.charms }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Download Artifact
@@ -145,7 +145,7 @@ jobs:
         path: ${{ fromjson(needs.build.outputs.charms) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Select charmhub channel
@@ -183,7 +183,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Select charmhub channel

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Setup Python

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Setup Charmcraft's pip cache

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Set up python

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Set up python

--- a/.github/workflows/_local-promote-train.yaml
+++ b/.github/workflows/_local-promote-train.yaml
@@ -44,7 +44,7 @@ jobs:
           - traefik-k8s-operator
     steps:
       - name: Checkout the charm repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: canonical/${{ matrix.charm-repo }}
       - name: Read the charm path from the Promote workflow

--- a/.github/workflows/bundle-pull-request.yaml
+++ b/.github/workflows/bundle-pull-request.yaml
@@ -37,14 +37,14 @@ jobs:
       any_modified: ${{ steps.echo-changes.outputs.any_modified }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }} # To be compatible with PRs from forks
           fetch-depth: 0
 
       - name: Determine changed files in the PR
         id: changed-files
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
+        uses: tj-actions/changed-files@v47
         with:
           files_ignore: |
             README.md

--- a/.github/workflows/charm-promote.yaml
+++ b/.github/workflows/charm-promote.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set target channel
         env:
           PROMOTE_FROM: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -56,14 +56,14 @@ jobs:
       any_modified: ${{ steps.echo-changes.outputs.any_modified }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }} # To be compatible with PRs from forks
           fetch-depth: 0
 
       - name: Determine changed files in the PR
         id: changed-files
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
+        uses: tj-actions/changed-files@v47
         with:
           files_ignore: |
             README.md

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -76,14 +76,14 @@ jobs:
       any_modified: ${{ steps.echo-changes.outputs.any_modified }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }} # To be compatible with PRs from forks
           fetch-depth: 0
 
       - name: Determine changed files in the PR
         id: changed-files
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
+        uses: tj-actions/changed-files@v47
         with:
           files_ignore: |
             README.md
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           path: charm

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -12,10 +12,10 @@ jobs:
       versions: ${{ steps.changed-versions.outputs.versions }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Find rockcraft.yaml changes
         id: changed-files
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
+        uses: tj-actions/changed-files@v47
         with:
           files: "**/rockcraft.yaml"
       - name: Extract the versions
@@ -36,7 +36,7 @@ jobs:
     if: needs.changes.outputs.versions != ''
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo snap install concierge --classic

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install dependencies
       run: |
         sudo snap install concierge --classic

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the rock repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: rock
           fetch-depth: 2 # Needed to check modified files
       - name: Get the changed rockcraft.yaml files
         id: changed-files
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
+        uses: tj-actions/changed-files@v47
         with:
           path: rock
           files: '**/rockcraft.yaml'
@@ -44,7 +44,7 @@ jobs:
       - name: Clone the fork
         id: fork-clone
         if: steps.changed-files.outputs.all_changed_and_modified_files != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: oci-factory
           repository: observability-noctua-bot/oci-factory

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -65,7 +65,7 @@ jobs:
           echo "release=$TAG" >> $GITHUB_OUTPUT
 
       - name: Checkout the rock source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: main
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Checkout application source for the Go version check
         if: inputs.check-go && steps.check.outputs.release != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.source-repo }}
           ref: ${{ steps.check.outputs.release }}

--- a/.github/workflows/terraform-quality-checks.yaml
+++ b/.github/workflows/terraform-quality-checks.yaml
@@ -8,6 +8,6 @@ jobs:
         name: Terraform lint
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: hashicorp/setup-terraform@v3
             - run: terraform fmt -check -recursive -diff


### PR DESCRIPTION
Implements the same fixes as https://github.com/canonical/observability/commit/e5d2a49f871a6489e3bd7a05c922a71fbda8ee66#diff-1e6b203b8a76de8044768488b6a6a9413f6c9fcb6b60f432b9ac45d4e599df9c but against the v0 branch