### PR TITLE
chore: bump setup python

### DIFF
--- a/.github/workflows/_charm-linting.yaml
+++ b/.github/workflows/_charm-linting.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install dependencies

--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -121,6 +121,7 @@ jobs:
       ip-range: ${{ inputs.ip-range }}
       charmcraft-channel: ${{ inputs.charmcraft-channel }}
       juju-channel: ${{ inputs.juju-channel }}
+      python-version: ${{ inputs.python-version }}
   codeql:
     name: CodeQL analysis
     needs:

--- a/.github/workflows/_charm-static-analysis.yaml
+++ b/.github/workflows/_charm-static-analysis.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install dependencies

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -29,6 +29,12 @@ on:
         required: false
         description: |
           The snap channel from which to install Juju.
+      python-version:
+        type: string
+        default: "3.8"
+        required: false
+        description: |
+          The Python version to use for integration tests.
 # Default to bash
 defaults:
   run:
@@ -44,6 +50,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
       - name: Setup Charmcraft's pip cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/_charm-tests-integration.yaml
+++ b/.github/workflows/_charm-tests-integration.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
       - name: Setup Charmcraft's pip cache

--- a/.github/workflows/_charm-tests-scenario.yaml
+++ b/.github/workflows/_charm-tests-scenario.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install dependencies

--- a/.github/workflows/_charm-tests-unit.yaml
+++ b/.github/workflows/_charm-tests-unit.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install dependencies

--- a/.github/workflows/bundle-pull-request.yaml
+++ b/.github/workflows/bundle-pull-request.yaml
@@ -101,3 +101,4 @@ jobs:
       charm-path: "${{ inputs.bundle-path }}"
       provider: "${{ inputs.provider }}"
       ip-range: ${{ inputs.ip-range }}
+      python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
No breaking changes. The action had two major version updates simply to bump node:

- https://github.com/actions/setup-python/releases/tag/v5.0.0 move to node 20
- https://github.com/actions/setup-python/releases/tag/v6.0.0 move to node 24