### PR TITLE
fix: TF release path override

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -83,6 +83,16 @@ on:
         default: ''
         required: false
         type: string
+      terraform-path:
+        description: |
+          Path to the Terraform module, relative to the repository root.
+          When empty (the default), this is derived as '<charm-path>/terraform'.
+          Set this explicitly for repos whose Terraform module does not live
+          under the charm directory (e.g. a root-level 'terraform/' while the
+          charm lives under 'charm/').
+        default: ''
+        required: false
+        type: string
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -269,5 +279,5 @@ jobs:
     with:
       terraform-tag-prefix: "${{ inputs.terraform-tag-prefix }}"
       terraform-tag-suffix: "${{ inputs.terraform-tag-suffix }}"
-      terraform-path: "${{ inputs.charm-path }}/terraform"
+      terraform-path: "${{ inputs.terraform-path != '' && inputs.terraform-path || format('{0}/terraform', inputs.charm-path) }}"
       track: "${{ inputs.track }}"


### PR DESCRIPTION
Related:
- https://github.com/canonical/catalogue-k8s-operator/pull/248

This CI run determined that there were no changes, when there actually were:
- https://github.com/canonical/catalogue-k8s-operator/actions/runs/28532778587/job/84589603192#step:4:1

This is because some charms have TF hosted in different dirs than charm source code.