### PR TITLE
feat: Lint TF docs step

### DIFF
--- a/.github/workflows/_charm-quality-checks.yaml
+++ b/.github/workflows/_charm-quality-checks.yaml
@@ -142,6 +142,20 @@ jobs:
           else
             echo "Terraform directory ($CHARM_PATH/terraform) does not exist. Skipping validation."
           fi
+      - name: Lint docs
+        env:
+          CHARM_PATH: "${{ inputs.charm-path }}"
+        run: |
+          if [ -d "$CHARM_PATH/terraform" ]; then
+            sudo snap install terraform-docs --classic
+            terraform-docs --config "$CHARM_PATH/.tfdocs.yaml" "$CHARM_PATH/terraform"
+            git diff --exit-code "$CHARM_PATH/terraform" || {
+              echo "::error::Terraform docs are out of date. Run 'just terraform-docs' and commit."
+              exit 1
+            }
+          else
+            echo "Terraform directory ($CHARM_PATH/terraform) does not exist. Skipping docs validation."
+          fi
 
   static-analysis:
     name: Static analysis

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -125,7 +125,7 @@ jobs:
     needs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
-    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v2
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@feat/tf-docs-lint
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -125,7 +125,7 @@ jobs:
     needs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
-    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@feat/tf-docs-lint
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v2
     secrets: inherit
     with:
       charm-path: ${{ inputs.charm-path }}


### PR DESCRIPTION
## Issue
We are not linting the README.md files in the Terraform modules.

Fixes https://github.com/canonical/observability/issues/439

## Solution
Add a terraform-docs step to the `Validate Terraform files` job. We already have a [.tfdocs.yaml](https://github.com/canonical/observability/blob/main/blueprints/charms/.tfdocs.yaml) file for all charm modules since we have the charm.just blueprint synced to those repos.

## Testing
Here are (testing/temp) tandem PRs which implement this workflow:
- https://github.com/canonical/alertmanager-k8s-operator/pull/456
	- ✅ Passing
		- [Lint docs step](https://github.com/canonical/alertmanager-k8s-operator/actions/runs/30274747800/job/90005889076?pr=456#step:4:1)
	- ❌ Failing
		- [Lint docs step](https://github.com/canonical/alertmanager-k8s-operator/actions/runs/30275822757/job/90009543261?pr=456#step:4:1)
- https://github.com/canonical/loki-operators/pull/304
	- ✅ Passing
		- [Lint docs step (coordinator)](https://github.com/canonical/loki-operators/actions/runs/30275197738/job/90007492538?pr=304#step:4:1)
		- [Lint docs step (worker)](https://github.com/canonical/loki-operators/actions/runs/30275197738/job/90007398064?pr=304#step:4:1)
	- ❌ Failing
		- [Lint docs step (coordinator)](https://github.com/canonical/loki-operators/actions/runs/30275817022/job/90009604087?pr=304#step:4:1)
		- Worker succeeds because there were no changes

> [!WARNING]
> Linting for the component module is currently not supported; although, it should be. Not sure how we want to handle this because the [charm-path is specific to the coordinator and worker paths](https://github.com/canonical/loki-operators/blob/b838f0f77efbf7608ccd6cc87ac0e8271b2a1944/.github/workflows/pull-request.yaml#L18), excluding the component module.

## Checklist
- [ ] We need to add this feature to the `v2` tag so that all charm modules pick it up automatically.
- [x] Close these 2 PRs: [alertmanager](https://github.com/canonical/alertmanager-k8s-operator/pull/456), [loki-operators](https://github.com/canonical/loki-operators/pull/304)
- [ ] Create a tandem issue for the component module terraform-docs support.