### PR TITLE
ci(rocks): fix rock-path handling in oci-factory workflow

### DIFF
--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -35,7 +35,6 @@ jobs:
       - name: Checkout the rock repository
         uses: actions/checkout@v6
         with:
-          path: ${{ inputs.rock-path }}
           fetch-depth: 2 # Needed to check modified files
       - name: Find rockcraft.yaml changes
         id: changed-files
@@ -85,6 +84,7 @@ jobs:
         env:
           versions: ${{ steps.changed-versions.outputs.versions }}
         run: |
+          cd "${{ inputs.rock-path }}"
           for version in $versions; do
             just pack "$version"
           done
@@ -94,6 +94,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
           versions: ${{ steps.changed-versions.outputs.versions }}
         run: |
+          cd "${{ inputs.rock-path }}"
           for version in $versions; do
             echo "Releasing version $version to OCI Factory on track ${{ inputs.risk-track }}"
             just release-oci-factory "$version" ${{ inputs.rock-support }} ${{ inputs.risk-track }}


### PR DESCRIPTION
## Problem

`rock-release-oci-factory.yaml` fails with `error: no justfile found` for any caller that passes a non-default `rock-path` (e.g. a monorepo like [`canonical/service-mesh`](https://github.com/canonical/service-mesh/actions/runs/30018199249/job/89243755145)).

Two mistakes, both diverging from the sibling `rock-release-dev.yaml` and `rock-pull-request.yaml` workflows which handle `rock-path` correctly:

1. The checkout uses `path: ${{ inputs.rock-path }}`, nesting the whole repo into a subdirectory. This also makes `tj-actions/changed-files` emit repo-root-relative paths, so `versions` end up prefixed (`rocks/foo-rock/1.30.3`) instead of bare (`1.30.3`).
2. The **Pack the rocks** and **Release to OCI Factory** steps run `just …` from the workspace root, which has no justfile.

## Fix

Match the working siblings: check out at the workspace root, and `cd "${{ inputs.rock-path }}"` before invoking `just`.

## Issue 
https://github.com/canonical/service-mesh/issues/205