### PR TITLE
fix: do not cancel concurrent OCI factory jobs if they have a different rock-path

### DIFF
--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -1,7 +1,7 @@
 name: Open a PR to OCI Factory when a new rock is merged to main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (inputs.rock-path && inputs.rock-path != '.') && format('-{0}', inputs.rock-path) || '' }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
Concurrent task runs are cancelled except for one when the workflow is used in a monorepo to release multiple rocks at the same time.

This change is consistent with the solution of [`charm-release.yaml`](https://github.com/canonical/observability/blob/c71c99a70d8efa2e483bdd0c9cadd12bbb5cb7e9/.github/workflows/charm-release.yaml#L100).
