### PR TITLE
ci: use concierge to set up charm release build environment

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -99,25 +99,17 @@ jobs:
           fetch-depth: 0
       - name: Install dependencies
         env:
-          CHARMCRAFT_CHANNEL: ${{ inputs.charmcraft-channel }}
+          CONCIERGE_CHARMCRAFT_CHANNEL: ${{ inputs.charmcraft-channel }}
+          CONCIERGE_EXTRA_SNAPS: "astral-uv,yq"
         run: |
-          # Install LXD
-          # concierge breaks charmcraft: https://github.com/jnsgruk/concierge/issues/28
-          sudo snap install lxd
-          sudo lxd waitready
-          sudo lxd init --minimal
-          sudo lxc network set lxdbr0 ipv6.address none
-          # Enable non-root user control
-          sudo chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-          lxd_user="$USER"
-          sudo usermod -a -G lxd "$lxd_user"
-          # Ensure that LXD containers can talk to the internet
-          sudo iptables -F FORWARD
-          sudo iptables -P FORWARD ACCEPT
-          # Install other snaps
-          sudo snap install charmcraft --classic --channel="$CHARMCRAFT_CHANNEL"
-          sudo snap install astral-uv --classic
-          sudo snap install yq
+          # Use concierge (crafts preset) to set up LXD and charmcraft. The
+          # crafts preset installs lxd + charmcraft without bootstrapping juju,
+          # which the release job never uses. It also refreshes LXD to a version
+          # that can pack newer bases (e.g. the 26.04 buildd base that needs the
+          # systemd-resolved-in-container fix from LXD 6.9), which a plain
+          # `snap install lxd` no-ops on runners that already have an older LXD.
+          sudo snap install concierge --classic
+          sudo -E concierge prepare -p crafts
       - name: Get charm name
         id: get-charm-name
         run: |

--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -101,13 +101,17 @@ jobs:
         env:
           CONCIERGE_CHARMCRAFT_CHANNEL: ${{ inputs.charmcraft-channel }}
           CONCIERGE_EXTRA_SNAPS: "astral-uv,yq"
+          # Pin LXD to latest/stable so runners already tracking an older
+          # channel (e.g. 5.21/stable) actually move to a version that can pack
+          # newer bases. The 26.04 buildd base needs the systemd-resolved-in-
+          # container fix, which only landed in LXD 6.x (latest), not 5.21.
+          CONCIERGE_LXD_CHANNEL: latest/stable
         run: |
           # Use concierge (crafts preset) to set up LXD and charmcraft. The
           # crafts preset installs lxd + charmcraft without bootstrapping juju,
-          # which the release job never uses. It also refreshes LXD to a version
-          # that can pack newer bases (e.g. the 26.04 buildd base that needs the
-          # systemd-resolved-in-container fix from LXD 6.9), which a plain
-          # `snap install lxd` no-ops on runners that already have an older LXD.
+          # which the release job never uses. concierge refreshes an already-
+          # installed LXD (a plain `snap install lxd` no-ops), and the pinned
+          # channel above ensures the refresh crosses over to a fixed version.
           sudo snap install concierge --classic
           sudo -E concierge prepare -p crafts
       - name: Get charm name

--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -101,17 +101,10 @@ jobs:
         env:
           CONCIERGE_CHARMCRAFT_CHANNEL: ${{ inputs.charmcraft-channel }}
           CONCIERGE_EXTRA_SNAPS: "astral-uv,yq"
-          # Pin LXD to latest/stable so runners already tracking an older
-          # channel (e.g. 5.21/stable) actually move to a version that can pack
-          # newer bases. The 26.04 buildd base needs the systemd-resolved-in-
-          # container fix, which only landed in LXD 6.x (latest), not 5.21.
+          # The self-hosted arm64 runner tracks an older LXD channel that can't
+          # pack the 26.04 base; pin to latest/stable to refresh onto the fix.
           CONCIERGE_LXD_CHANNEL: latest/stable
         run: |
-          # Use concierge (crafts preset) to set up LXD and charmcraft. The
-          # crafts preset installs lxd + charmcraft without bootstrapping juju,
-          # which the release job never uses. concierge refreshes an already-
-          # installed LXD (a plain `snap install lxd` no-ops), and the pinned
-          # channel above ensures the refresh crosses over to a fixed version.
           sudo snap install concierge --classic
           sudo -E concierge prepare -p crafts
       - name: Get charm name


### PR DESCRIPTION
## Why

The charm release workflow set up LXD and charmcraft by hand and never refreshed an already-installed LXD. On runners that already have an older LXD (e.g. the self-hosted arm64 runner), `snap install lxd` is a no-op, so the build kept using a stale LXD that cannot pack newer Ubuntu bases.

Concretely, packing the Ubuntu 26.04 base fails with `Failed to setup systemd-resolved` because it needs the systemd-resolved-in-container fix shipped in LXD 6.9 ([lxd#17073](https://github.com/canonical/lxd/issues/17073) / [lxd#17223](https://github.com/canonical/lxd/pull/17223)). This broke arm64 release builds during the pack step.

## What

- Replace the manual LXD + charmcraft setup with concierge using the `crafts` preset.
- `crafts` provisions LXD and charmcraft (and refreshes LXD to a working version) without bootstrapping juju, which the release job never uses.
- Keep `astral-uv` and `yq` via `CONCIERGE_EXTRA_SNAPS`.

This mirrors how the quality-checks workflow already relies on concierge, and drops the now-obsolete "concierge breaks charmcraft" workaround.