### PR TITLE
feat(ci): native per-architecture charm and snap builds

### DIFF
--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -37,6 +37,15 @@ on:
         default: false
         required: false
         type: boolean
+      pack-using-self-hosted-runners:
+        description: |
+          When packing the charm for release, fan out one native build per
+          architecture onto self-hosted runners (and GitHub-hosted runners for
+          amd64). Each leg packs all the Ubuntu bases present in
+          `charmcraft.yaml` for its architecture.
+        default: false
+        required: false
+        type: boolean
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -61,6 +70,7 @@ jobs:
         env:
           CHARM_PATH: ${{ inputs.charm-path }}
           PACK_REMOTE: ${{ inputs.pack-using-remote-build }}
+          PACK_SELF_HOSTED: ${{ inputs.pack-using-self-hosted-runners }}
           RUNNERS: ${{ inputs.runners }}
         run: |
           if [[ "$PACK_REMOTE" == "true" ]]; then
@@ -72,16 +82,38 @@ jobs:
               yq -o=json -I=0 '.platforms | keys' "$CHARM_PATH/charmcraft.yaml" \
                 | jq -c '{"include": map({"runner": "ubuntu-latest", "platform": .})}'
             )"
+          elif [[ "$PACK_SELF_HOSTED" == "true" ]]; then
+            # Native build: fan out one leg per architecture found in
+            # charmcraft.yaml. Each leg packs all Ubuntu bases for its arch on
+            # a runner matching that arch (GitHub-hosted for amd64, self-hosted
+            # otherwise). The `arch` value is used later to strip charmcraft.yaml
+            # down to just that architecture's platforms before packing.
+            #
+            # Platform keys may be either a bare arch (e.g. `amd64`) or an
+            # `ubuntu@<ver>:<arch>` form; extract the arch from either shape.
+            matrix="$(
+              yq -o=json -I=0 '.platforms | keys' "$CHARM_PATH/charmcraft.yaml" \
+                | jq -c '
+                    def arch_of: sub(".*:"; "");
+                    def runner_for(a):
+                      if a == "amd64" then "ubuntu-latest"
+                      elif a == "arm64" then "Ubuntu_ARM64_4C_16G_03"
+                      else "self-hosted-linux-" + a + "-resolute-medium"
+                      end;
+                    map(arch_of) | unique
+                    | {"include": map({"runner": runner_for(.), "arch": ., "platform": ""})}
+                  '
+            )"
           else
             # Local build: preserve the previous behavior of one leg per
             # caller-supplied runner, with no per-platform filtering.
-            matrix="$(echo "$RUNNERS" | jq -c '{"include": map({"runner": ., "platform": ""})}')"
+            matrix="$(echo "$RUNNERS" | jq -c '{"include": map({"runner": ., "platform": "", "arch": ""})}')"
           fi
           echo "matrix=$matrix"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   build:
-    name: Release the charm${{ matrix.platform && format(' ({0})', matrix.platform) || '' }}
+    name: Release the charm${{ matrix.platform && format(' ({0})', matrix.platform) || matrix.arch && format(' ({0})', matrix.arch) || '' }}
     needs: [define-matrix]
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -125,9 +157,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-wheel-cache-
       - name: Pack charm(s) locally
-        if: ${{ !inputs.pack-using-remote-build }}
+        if: ${{ !inputs.pack-using-remote-build && !inputs.pack-using-self-hosted-runners }}
         run: |
           cd "${{ inputs.charm-path }}"
+          charmcraft pack -v
+          charms="$(basename -a ./*.charm | jq -R -s -c 'split("\n")[:-1]')"
+          echo "charms=$charms"
+          echo "charms=$charms" >> "$GITHUB_OUTPUT"
+      - name: Pack charm(s) natively per architecture
+        if: ${{ inputs.pack-using-self-hosted-runners }}
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          cd "${{ inputs.charm-path }}"
+          # Keep only this architecture's platforms so a single native runner
+          # packs every Ubuntu base for its arch (and nothing for other archs).
+          # Platform keys are either a bare arch (`amd64`) or `ubuntu@<ver>:<arch>`.
+          yq -i '.platforms |= with_entries(select(.key == strenv(ARCH) or (.key | test(":" + strenv(ARCH) + "$"))))' charmcraft.yaml
           charmcraft pack -v
           charms="$(basename -a ./*.charm | jq -R -s -c 'split("\n")[:-1]')"
           echo "charms=$charms"
@@ -156,6 +202,7 @@ jobs:
         id: artifact-name
         env:
           PLATFORM: ${{ matrix.platform }}
+          ARCH: ${{ matrix.arch }}
           RUNNER_ARCH: ${{ runner.arch }}
           CHARM_PATH: ${{ inputs.charm-path }}
         run: |
@@ -166,6 +213,11 @@ jobs:
           # while still keeping the platform identifiable in the artifact name.
           if [[ -n "$PLATFORM" ]]; then
             suffix="$(printf '%s' "$PLATFORM" | tr ':"/\\<>|*?' '-')"
+          elif [[ -n "$ARCH" ]]; then
+            # Self-hosted per-arch legs: `runner.arch` reports GitHub's coarse
+            # value (e.g. X64) and cannot express s390x/ppc64el, so use the
+            # matrix arch to keep parallel legs' artifacts distinct.
+            suffix="$ARCH"
           else
             suffix="$RUNNER_ARCH"
           fi

--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -12,15 +12,6 @@ on:
         type: string
         required: false
         default: .
-      runners:
-        description: |
-          Json matrix of the runners to use to build and release the charm.
-          Example: ["ubuntu-latest","Ubuntu_ARM64_4C_16G_03"]
-          Ignored when `pack-using-remote-build` is true; in that case the
-          matrix is derived from `.platforms` in `charmcraft.yaml`.
-        type: string
-        required: false
-        default: '["ubuntu-latest"]'
       charmcraft-channel:
         type: string
         required: true
@@ -34,15 +25,6 @@ on:
         description: |
           When packing the charm for release, use remote-build.
           Remote-building is useful when you want to pack and release a charm for archs such as S390x or PPC64EL.
-        default: false
-        required: false
-        type: boolean
-      pack-using-self-hosted-runners:
-        description: |
-          When packing the charm for release, fan out one native build per
-          architecture onto self-hosted runners (and GitHub-hosted runners for
-          amd64). Each leg packs all the Ubuntu bases present in
-          `charmcraft.yaml` for its architecture.
         default: false
         required: false
         type: boolean
@@ -70,8 +52,6 @@ jobs:
         env:
           CHARM_PATH: ${{ inputs.charm-path }}
           PACK_REMOTE: ${{ inputs.pack-using-remote-build }}
-          PACK_SELF_HOSTED: ${{ inputs.pack-using-self-hosted-runners }}
-          RUNNERS: ${{ inputs.runners }}
         run: |
           if [[ "$PACK_REMOTE" == "true" ]]; then
             # Fan out one matrix leg per `platforms:` entry in charmcraft.yaml,
@@ -82,12 +62,14 @@ jobs:
               yq -o=json -I=0 '.platforms | keys' "$CHARM_PATH/charmcraft.yaml" \
                 | jq -c '{"include": map({"runner": "ubuntu-latest", "platform": .})}'
             )"
-          elif [[ "$PACK_SELF_HOSTED" == "true" ]]; then
-            # Native build: fan out one leg per architecture found in
+          else
+            # Native build (default): fan out one leg per architecture found in
             # charmcraft.yaml. Each leg packs all Ubuntu bases for its arch on
-            # a runner matching that arch (GitHub-hosted for amd64, self-hosted
-            # otherwise). The `arch` value is used later to strip charmcraft.yaml
-            # down to just that architecture's platforms before packing.
+            # a runner matching that arch (GitHub-hosted for amd64, the dedicated
+            # Ubuntu_ARM64 runner for arm64, and self-hosted runners for the
+            # remaining architectures such as s390x/ppc64el). The `arch` value is
+            # used later to strip charmcraft.yaml down to just that
+            # architecture's platforms before packing.
             #
             # Platform keys may be either a bare arch (e.g. `amd64`) or an
             # `ubuntu@<ver>:<arch>` form; extract the arch from either shape.
@@ -104,10 +86,6 @@ jobs:
                     | {"include": map({"runner": runner_for(.), "arch": ., "platform": ""})}
                   '
             )"
-          else
-            # Local build: preserve the previous behavior of one leg per
-            # caller-supplied runner, with no per-platform filtering.
-            matrix="$(echo "$RUNNERS" | jq -c '{"include": map({"runner": ., "platform": "", "arch": ""})}')"
           fi
           echo "matrix=$matrix"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
@@ -165,16 +143,8 @@ jobs:
           # portion of the dependencies, and restore-keys can partially match a cache.
           restore-keys: |
             ${{ runner.os }}-wheel-cache-
-      - name: Pack charm(s) locally
-        if: ${{ !inputs.pack-using-remote-build && !inputs.pack-using-self-hosted-runners }}
-        run: |
-          cd "${{ inputs.charm-path }}"
-          charmcraft pack -v
-          charms="$(basename -a ./*.charm | jq -R -s -c 'split("\n")[:-1]')"
-          echo "charms=$charms"
-          echo "charms=$charms" >> "$GITHUB_OUTPUT"
       - name: Pack charm(s) natively per architecture
-        if: ${{ inputs.pack-using-self-hosted-runners }}
+        if: ${{ !inputs.pack-using-remote-build }}
         env:
           ARCH: ${{ matrix.arch }}
         run: |

--- a/.github/workflows/_charm-release.yaml
+++ b/.github/workflows/_charm-release.yaml
@@ -139,6 +139,15 @@ jobs:
         run: |
           sudo snap install concierge --classic
           sudo -E concierge prepare -p crafts
+      - name: Ensure uv is available
+        # The astral-uv snap has no s390x/ppc64el builds, so concierge silently
+        # skips it on those runners and `uvx` is missing. Install uv via the
+        # official standalone installer as a fallback when it isn't present.
+        run: |
+          if ! command -v uvx >/dev/null 2>&1; then
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
       - name: Get charm name
         id: get-charm-name
         run: |

--- a/.github/workflows/charm-promote.yaml
+++ b/.github/workflows/charm-promote.yaml
@@ -1,11 +1,7 @@
 name: Promote Charm
 
 on:
-  permissions:
-    contents: write
-    actions: read
-    security-events: write
-
+  workflow_call:
     inputs:
       charm-path:
         description: "Path to the charm we want to promote. Defaults to the current working directory."
@@ -28,6 +24,10 @@ jobs:
   promote:
     name: Promote Charm
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      actions: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/charm-promote.yaml
+++ b/.github/workflows/charm-promote.yaml
@@ -1,7 +1,11 @@
 name: Promote Charm
 
 on:
-  workflow_call:
+  permissions:
+    contents: write
+    actions: read
+    security-events: write
+
     inputs:
       charm-path:
         description: "Path to the charm we want to promote. Defaults to the current working directory."

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -19,7 +19,7 @@ on:
         type: string
       charmcraft-channel:
         type: string
-        default: "latest/candidate"
+        default: "latest/stable"
         required: false
         description: |
           The snap channel from which to install Charmcraft.

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -1,7 +1,11 @@
 name: Pull Request
 
 on:
-  workflow_call:
+  permissions:
+    contents: write
+    actions: read
+    security-events: write
+
     inputs:
       charm-path:
         description: "Path to the charm we want to publish. Defaults to the current working directory."

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -1,11 +1,7 @@
 name: Pull Request
 
 on:
-  permissions:
-    contents: write
-    actions: read
-    security-events: write
-
+  workflow_call:
     inputs:
       charm-path:
         description: "Path to the charm we want to publish. Defaults to the current working directory."
@@ -129,6 +125,10 @@ jobs:
     needs:
       - ci-ignore
     if: needs.ci-ignore.outputs.any_modified == 'true'
+    permissions:
+      contents: write
+      actions: read
+      security-events: write
     uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v2
     secrets: inherit
     with:

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -15,7 +15,7 @@ on:
         type: string
       charmcraft-channel:
         type: string
-        default: "latest/candidate"
+        default: "latest/stable"
         required: false
         description: |
           The snap channel from which to install Charmcraft.
@@ -174,7 +174,7 @@ jobs:
 
   quality-checks:
     name: Quality Checks
-    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@feat/self-hosted-runners
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v2
     needs: [define-matrix]
     secrets: inherit
     with:
@@ -191,7 +191,7 @@ jobs:
     needs:
       - define-matrix
       - quality-checks
-    uses: canonical/observability/.github/workflows/_charm-release.yaml@feat/self-hosted-runners
+    uses: canonical/observability/.github/workflows/_charm-release.yaml@v2
     secrets:
       CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
       LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
@@ -245,7 +245,7 @@ jobs:
     needs:
       - release-charm
     if: inputs.track != '' || (github.ref_name != 'main' && startsWith(github.ref_name, 'track/'))
-    uses: canonical/observability/.github/workflows/terraform-release.yaml@feat/self-hosted-runners
+    uses: canonical/observability/.github/workflows/terraform-release.yaml@v2
     secrets:
       OBSERVABILITY_NOCTUA_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
     with:

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -73,6 +73,16 @@ on:
         default: false
         required: false
         type: boolean
+      pack-using-self-hosted-runners:
+        description: |
+          When packing the charm for release, fan out one native build per
+          architecture onto self-hosted runners (GitHub-hosted for amd64,
+          the Ubuntu_ARM64 runner for arm64, and self-hosted runners for
+          s390x/ppc64el). Each leg packs all Ubuntu bases present in
+          `charmcraft.yaml` for its architecture.
+        default: false
+        required: false
+        type: boolean
       terraform-tag-prefix:
         description: "Tag prefix to use for the Terraform release tag."
         default: 'tf-'
@@ -161,8 +171,10 @@ jobs:
         run: |
           cd "${{ inputs.charm-path }}"
 
-          if [ "${{ inputs.pack-using-remote-build }}" = "true" ]; then
-            # If using remote build, just use ubuntu-latest
+          if [ "${{ inputs.pack-using-remote-build }}" = "true" ] || [ "${{ inputs.pack-using-self-hosted-runners }}" = "true" ]; then
+            # Remote-build and self-hosted per-arch builds derive their own
+            # matrix from charmcraft.yaml inside _charm-release.yaml, so the
+            # runners list here is unused; emit a harmless placeholder.
             runners='["ubuntu-latest"]'
           else
             # Normal logic: get runners from charmcraft.yaml
@@ -195,7 +207,7 @@ jobs:
 
   quality-checks:
     name: Quality Checks
-    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v2
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@feat/self-hosted-runners
     needs: [define-matrix]
     secrets: inherit
     with:
@@ -212,7 +224,7 @@ jobs:
     needs:
       - define-matrix
       - quality-checks
-    uses: canonical/observability/.github/workflows/_charm-release.yaml@v2
+    uses: canonical/observability/.github/workflows/_charm-release.yaml@feat/self-hosted-runners
     secrets:
       CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
       LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
@@ -224,6 +236,7 @@ jobs:
       charmcraft-channel: "${{ inputs.charmcraft-channel }}"
       git-tag-prefix: "${{ inputs.git-tag-prefix }}"
       pack-using-remote-build: ${{ inputs.pack-using-remote-build }}
+      pack-using-self-hosted-runners: ${{ inputs.pack-using-self-hosted-runners }}
       
   release-libs:
     name: Release any bumped charm library
@@ -267,7 +280,7 @@ jobs:
     needs:
       - release-charm
     if: inputs.track != '' || (github.ref_name != 'main' && startsWith(github.ref_name, 'track/'))
-    uses: canonical/observability/.github/workflows/terraform-release.yaml@v2
+    uses: canonical/observability/.github/workflows/terraform-release.yaml@feat/self-hosted-runners
     secrets:
       OBSERVABILITY_NOCTUA_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
     with:

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -73,16 +73,6 @@ on:
         default: false
         required: false
         type: boolean
-      pack-using-self-hosted-runners:
-        description: |
-          When packing the charm for release, fan out one native build per
-          architecture onto self-hosted runners (GitHub-hosted for amd64,
-          the Ubuntu_ARM64 runner for arm64, and self-hosted runners for
-          s390x/ppc64el). Each leg packs all Ubuntu bases present in
-          `charmcraft.yaml` for its architecture.
-        default: false
-        required: false
-        type: boolean
       terraform-tag-prefix:
         description: "Tag prefix to use for the Terraform release tag."
         default: 'tf-'
@@ -158,7 +148,6 @@ jobs:
     needs: [ci-ignore]
     if: needs.ci-ignore.outputs.any_modified == 'true'
     outputs:
-      runners: ${{ steps.build-matrix.outputs.runners }}
       release-channel: ${{ steps.define-channel.outputs.release_channel }}
     steps:
       - name: Checkout
@@ -166,28 +155,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install yq
-      - name: Define build matrix
-        id: build-matrix
-        run: |
-          cd "${{ inputs.charm-path }}"
-
-          if [ "${{ inputs.pack-using-remote-build }}" = "true" ] || [ "${{ inputs.pack-using-self-hosted-runners }}" = "true" ]; then
-            # Remote-build and self-hosted per-arch builds derive their own
-            # matrix from charmcraft.yaml inside _charm-release.yaml, so the
-            # runners list here is unused; emit a harmless placeholder.
-            runners='["ubuntu-latest"]'
-          else
-            # Normal logic: get runners from charmcraft.yaml
-            runners="$( \
-              yq -o json '.platforms | to_entries | map(.key)' charmcraft.yaml | \
-              sed 's/".*amd64.*"/"ubuntu-latest"/' | \
-              sed 's/".*arm64.*"/"Ubuntu_ARM64_4C_16G_03"/' | \
-              jq -rc 'unique' \
-            )"
-          fi
-
-          echo "runners=$runners"
-          echo "runners=$runners" >> "$GITHUB_OUTPUT"
       - name: Define release channel
         id: define-channel
         env:
@@ -232,11 +199,9 @@ jobs:
     with:
       release-channel: "${{ needs.define-matrix.outputs.release-channel }}"
       charm-path: "${{ inputs.charm-path }}"
-      runners: "${{ needs.define-matrix.outputs.runners }}"
       charmcraft-channel: "${{ inputs.charmcraft-channel }}"
       git-tag-prefix: "${{ inputs.git-tag-prefix }}"
       pack-using-remote-build: ${{ inputs.pack-using-remote-build }}
-      pack-using-self-hosted-runners: ${{ inputs.pack-using-self-hosted-runners }}
       
   release-libs:
     name: Release any bumped charm library

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -24,7 +24,7 @@ on:
         type: string
       charmcraft-channel:
         type: string
-        default: "latest/candidate"
+        default: "latest/stable"
         required: false
         description: |
           The snap channel from which to install Charmcraft.

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -14,12 +14,11 @@ on:
       # See https://documentation.ubuntu.com/snapcraft/stable/how-to/sign-in/
       SNAPCRAFT_STORE_CREDENTIALS:
         required: true
-      # Launchpad credentials for `snapcraft remote-build`.
-      # This is the contents of ~/.local/share/snapcraft/launchpad-credentials after
-      # running `snapcraft remote-build` locally and completing the OAuth flow.
-      # See https://documentation.ubuntu.com/snapcraft/stable/explanation/remote-build/
+      # Launchpad credentials, previously required for `snapcraft remote-build`.
+      # Native per-architecture builds no longer use remote-build, so this is
+      # kept optional for backward compatibility with existing callers.
       LAUNCHPAD_TOKEN:
-        required: true
+        required: false
 
 jobs:
   changes:
@@ -65,7 +64,22 @@ jobs:
             # Parse platforms from the snapcraft.yaml
             platforms="$(yq -r '.platforms | keys | .[]' "$snapcraft_file")"
             for platform in $platforms; do
-              matrix="$(echo "$matrix" | jq -c --arg v "$version" --arg p "$platform" '.include += [{"version": $v, "platform": $p}]')"
+              # Map each platform's architecture to a native runner so the snap
+              # is packed on matching hardware instead of remote-built on
+              # Launchpad: GitHub-hosted for amd64, the dedicated Ubuntu_ARM64
+              # runner for arm64, and self-hosted runners for the remaining
+              # architectures such as s390x/ppc64el. The platform key may be a
+              # bare arch (e.g. `amd64`) or an `<arch>` inside a larger string;
+              # extract the trailing arch either way.
+              arch="${platform##*:}"
+              case "$arch" in
+                amd64) runner="ubuntu-latest" ;;
+                arm64) runner="Ubuntu_ARM64_4C_16G_03" ;;
+                *)     runner="self-hosted-linux-${arch}-resolute-medium" ;;
+              esac
+              matrix="$(echo "$matrix" | jq -c \
+                --arg v "$version" --arg p "$platform" --arg r "$runner" \
+                '.include += [{"version": $v, "platform": $p, "runner": $r}]')"
             done
           done
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
@@ -74,14 +88,14 @@ jobs:
 
   release:
     name: Release ${{ matrix.version }} (${{ matrix.platform }})
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     needs: [changes]
     if: ${{ fromJSON(needs.changes.outputs.matrix).include[0] != null }}
     strategy:
       fail-fast: false
-      # Launchpad remote-build uses a shared git repo per snap, so parallel builds
-      # for different architectures race and fail. Run one at a time.
-      max-parallel: 1
+      # Native builds fan out across distinct runners, so there is no shared
+      # Launchpad git repo to serialize on; let all legs run in parallel.
+      max-parallel: 256
       matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
     steps:
       - name: Checkout repository
@@ -90,18 +104,12 @@ jobs:
         run: |
           sudo snap install concierge --classic
           sudo concierge prepare -p crafts --extra-snaps=just,yq
-      - name: Set up Launchpad credentials
-        env:
-          LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
-        run: |
-          mkdir -p "$HOME/.local/share/snapcraft"
-          echo -e "$LAUNCHPAD_TOKEN" > "$HOME/.local/share/snapcraft/launchpad-credentials"
       - name: Build and release snap
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: |
           cd "${{ inputs.snap-path }}"
-          just remote-build ${{ matrix.version }} ${{ matrix.platform }}
+          just pack ${{ matrix.version }} ${{ matrix.platform }}
           just release ${{ matrix.version }}
       - name: Open SSH session on failure
         if: ${{ failure() && (runner.debug == '1') }}


### PR DESCRIPTION
## Why

Releasing charms and snaps for less common architectures (s390x, ppc64el) previously relied on Launchpad remote-build, which is slow and serializes every architecture through a single shared build queue. This branch replaces that with native builds on architecture-matched runners, which are faster, run in parallel, and extend cleanly to any architecture.

## What changed

- **Charms build natively per architecture by default.** When remote-build is off, each architecture in `charmcraft.yaml` fans out to a matching runner (GitHub-hosted for amd64, a dedicated runner for arm64, self-hosted runners for s390x/ppc64el) and packs all its Ubuntu bases locally. This is a strict superset of the previous default behaviour, so the separate opt-in flag and the now-unused runners input were removed.
- **Snap releases use the same native strategy.** Snap builds now map each platform's architecture to a matching runner and pack locally instead of remote-building through Launchpad, so all legs run in parallel. The Launchpad token secret is now optional.
- **Default charmcraft channel is now `latest/stable`.** The edge channel shipped a charmcraft build that rejected valid Charmhub credentials during release; stable avoids that class of breakage.
- **Missing-permission fixes** for the promote and pull-request workflows, and a `uv` fallback installer for architectures where the uv snap has no build.

## Testing

Validated end-to-end on `o11y-tester-operator`: charms build and release successfully across amd64, arm64, s390x, and ppc64el, and integration tests reach active/idle.