### PR TITLE
feat: restructure rock blueprint to major.minor-only release folders

### DIFF
--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -49,7 +49,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
       run: |
         cd "${{ inputs.rock-path }}"
-        echo "latest_version=$(just --evaluate latest_version)" >> "$GITHUB_ENV"
+        echo "latest_version=$(just latest-version)" >> "$GITHUB_ENV"
         just pack
         just release-ghcr
     - name: Create SBOM

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -49,7 +49,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
       run: |
         cd "${{ inputs.rock-path }}"
-        echo "latest_version=$(just latest-version)" >> "$GITHUB_ENV"
+        echo "latest_version=$(just --evaluate latest_version)" >> "$GITHUB_ENV"
         just pack
         just release-ghcr
     - name: Create SBOM

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -1,5 +1,7 @@
-# This action automatically creates a folder with the same name as the upstream version
-name: Update rock on new releases of its source
+# This action patches existing major.minor folders to their newest upstream
+# patch release. It never creates new folders: onboarding a new major.minor
+# release line is a deliberate, manual action via 'just add-version'.
+name: Update rock on new patch releases of its source
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,7 +16,7 @@ on:
         default: "."
         type: string
       source-repo:
-        description: "Repository of the source application in 'org/repo' form"
+        description: "Repository of the source application in 'org/repo' form (used for the PR body link; 'source_repo' must also be set in the rock's local justfile)"
         required: true
         type: string
       commit-username:
@@ -45,17 +47,17 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Merge any pre-existing PRs from the automatically generated "chore/add-version" branch if the CI is green
+      - name: Merge any pre-existing PRs from the automatically generated "chore/update-patches" branch if the CI is green
         run: |
-          # If a PR from "chore/add-version" is open and CI checks are passing, merge it
-          is_pr_open="$(gh pr list --head chore/add-version --state open --json id --jq 'length')"
+          # If a PR from "chore/update-patches" is open and CI checks are passing, merge it
+          is_pr_open="$(gh pr list --head chore/update-patches --state open --json id --jq 'length')"
           if [[ "$is_pr_open" == "1" ]]; then
-            if gh pr checks chore/add-version; then
-              echo "CI checks are passing, merging the chore/add-version PR"
-              gh pr merge chore/add-version --admin --squash --delete-branch
+            if gh pr checks chore/update-patches; then
+              echo "CI checks are passing, merging the chore/update-patches PR"
+              gh pr merge chore/update-patches --admin --squash --delete-branch
             else
-              echo "CI checks are not passing for the existing chore/add-version PR, adding a comment."
-              gh pr comment chore/add-version --body "This PR cannot be automatically merged because CI checks are not passing. Please check the CI results, resolve any issues, and merge the PR manually."
+              echo "CI checks are not passing for the existing chore/update-patches PR, adding a comment."
+              gh pr comment chore/update-patches --body "This PR cannot be automatically merged because CI checks are not passing. Please check the CI results, resolve any issues, and merge the PR manually."
             fi
           elif [[ "$is_pr_open" != "0" ]]; then
             # The number of open PRs should always be either 0 or 1
@@ -65,7 +67,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
   update:
-    name: Update the rock for new upstream releases
+    name: Patch existing major.minor folders to their newest upstream release
     runs-on: ubuntu-latest
     needs:
       - merge-pr
@@ -77,19 +79,19 @@ jobs:
           sudo snap install just --classic
           sudo snap install jq
           sudo snap install yq
-      - name: Check for new upstream releases and create the rock if needed
-        id: check-and-update
+      - name: Patch existing major.minor folders
+        id: update
         env:
           GH_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
         run: |
           cd "${{ inputs.rock-path }}"
-          just update ${{ inputs.source-repo }}
-          new_version="$(git status --short | grep '^??' | awk '{print $2}' | sed 's@/$@@')"
+          just update
+          updated_folders="$(git status --short -- '*/rockcraft.yaml' | awk '{print $2}' | xargs -n1 dirname | tr '\n' ' ')"
           echo "rock_name=$(just name)" >> "$GITHUB_OUTPUT"
-          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+          echo "updated_folders=$updated_folders" >> "$GITHUB_OUTPUT"
 
       - name: Import and configure the GPG key for Noctua
-        if: steps.check-and-update.outputs.new_version != ''
+        if: steps.update.outputs.updated_folders != ''
         uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.NOCTUA_GPG_PRIVATE }}
@@ -99,14 +101,14 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Create a PR
-        if: steps.check-and-update.outputs.new_version != ''
+        if: steps.update.outputs.updated_folders != ''
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
-          commit-message: "chore(deps): bump ${{ steps.check-and-update.outputs.rock_name }} version to ${{ steps.check-and-update.outputs.new_version }}"
+          commit-message: "chore(deps): bump ${{ steps.update.outputs.rock_name }} patch releases (${{ steps.update.outputs.updated_folders }})"
           committer: "${{ inputs.commit-username }} <${{ inputs.commit-email }}>"
           author: "${{ inputs.commit-username }} <${{ inputs.commit-email }}>"
-          title: "chore: add rock for ${{ steps.check-and-update.outputs.rock_name }} ${{ steps.check-and-update.outputs.new_version }}"
-          body: Automated update to follow upstream [release](https://github.com/${{ inputs.source-repo }}/releases/tag/${{ steps.check-and-update.outputs.new_version }}) of ${{ steps.check-and-update.outputs.rock_name }}.
-          branch: "chore/add-version"
+          title: "chore: bump ${{ steps.update.outputs.rock_name }} patch releases (${{ steps.update.outputs.updated_folders }})"
+          body: Automated patch update to follow upstream [releases](https://github.com/${{ inputs.source-repo }}/releases) of ${{ steps.update.outputs.rock_name }} for the following major.minor folders&colon; `${{ steps.update.outputs.updated_folders }}`.
+          branch: "chore/update-patches"
           delete-branch: true

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -15,10 +15,6 @@ on:
         required: false
         default: "."
         type: string
-      source-repo:
-        description: "Repository of the source application in 'org/repo' form (used for the PR body link; 'source_repo' must also be set in the rock's local justfile)"
-        required: true
-        type: string
       commit-username:
         description: "The username to use for committing the updates on the charm libraries"
         default: 'Noctua'
@@ -109,6 +105,6 @@ jobs:
           committer: "${{ inputs.commit-username }} <${{ inputs.commit-email }}>"
           author: "${{ inputs.commit-username }} <${{ inputs.commit-email }}>"
           title: "chore: bump ${{ steps.update.outputs.rock_name }} patch releases (${{ steps.update.outputs.updated_folders }})"
-          body: Automated patch update to follow upstream [releases](https://github.com/${{ inputs.source-repo }}/releases) of ${{ steps.update.outputs.rock_name }} for the following major.minor folders&colon; `${{ steps.update.outputs.updated_folders }}`.
+          body: Automated patch update to follow upstream releases of ${{ steps.update.outputs.rock_name }} for the following major.minor folders&colon; `${{ steps.update.outputs.updated_folders }}`.
           branch: "chore/update-patches"
           delete-branch: true

--- a/blueprints/rocks/README.md
+++ b/blueprints/rocks/README.md
@@ -9,32 +9,66 @@ When bootstrapping a new rock, initialize it with the files from this folder so 
 
 ```
 rock-name
-├── justfile     # Main justfile: imports 'rock.just' and allows for overrides
-├── README.md    # This README
-├── rocks.just    # (*) Shared rock recipes
-└── spread.yaml  # (*) Shared spread configuration
+├── justfile     # Main justfile: imports 'rocks.just' and allows for overrides
+├── rocks.just   # (*) Shared rock recipes
+├── spread.yaml  # (*) Shared spread configuration
+└── X.Y/         # One per maintained release line, manually created
+    └── rockcraft.yaml
 ```
 
-To refresh the centralized files, run `just refresh`.
+## Versioning & Release Lines
 
-For project-specific customizations, see [../README.md#customization](../README.md#customization).
-
-## Folder structure
-
-Each rock repository keeps one folder per maintained `major.minor` release
-line (e.g. `0.31/`, `0.32/`, `0.33/`), each with its own `rockcraft.yaml`.
-There is no `latest/` folder: the concrete version and upstream tag are
-recorded inside each folder's `rockcraft.yaml` (`version` +
+There is no `latest/` folder for rocks. Every maintained upstream `major.minor`
+release line has its own `X.Y/` folder, with the concrete version and upstream
+tag recorded inside that folder's `rockcraft.yaml` (`version` and
 `parts.<name>.source-tag`), not in the folder name.
 
-- **New release lines are added manually**, roughly every six months, via
-  `just add-version <version>`. This resolves the newest real upstream tag on
-  the given `major.minor` line and fails if none exists.
-- **The scheduled `update` automation only patches existing folders** to the
-  newest upstream patch of their own line. It never creates a new folder or
-  jumps to a new minor, so onboarding a new release line stays a deliberate,
-  reviewed action.
+`X.Y/` folders are **manually created** when you want to maintain a specific
+release line.
+
+| Folder | Created  |
+|--------|----------|
+| `X.Y/` | Manually |
+
+### Automatic Updates
+
+The `just update` recipe:
+
+1. Fetches upstream releases for the repo set in the `source_repo` variable
+2. For each existing `X.Y/` folder, finds the newest upstream patch on that line
+3. If upstream is newer, updates that folder's `rockcraft.yaml` (`version` +
+   `source-tag`)
+
+This never creates or removes an `X.Y/` folder, so onboarding a new release
+line is always intentional.
+
+### Creating a New Release Line
+
+To add support for a new `X.Y` release line:
+
+```bash
+just add-version X.Y
+```
+
+This resolves the newest real upstream tag on the given `major.minor` line and
+fails if none exists.
+
+## Recipes
+
+| Recipe | Description |
+|--------|-------------|
+| `just update` | Patch existing `X.Y/` folders to their newest upstream release |
+| `just add-version <version>` | Create a new `X.Y/` release line |
+| `just pack [version]` | Build a rock locally |
+| `just test [version]` | Run spread tests |
+| `just scan [version]` | Generate SBOM and run a vulnerability scan |
+| `just release-ghcr [version]` | Push a `:dev` tag to GHCR |
+| `just release-oci-factory [version]` | Open a PR to OCI Factory |
+| `just refresh` | Fetch latest centralized files |
 
 Set `source_repo` (upstream `org/repo`) in the repository's local `justfile`
 so `update`, `add-version`, and `govulncheck` don't need it passed explicitly.
 
+To refresh the centralized files, run `just refresh`.
+
+For project-specific customizations, see [../README.md#customization](../README.md#customization).

--- a/blueprints/rocks/README.md
+++ b/blueprints/rocks/README.md
@@ -18,3 +18,23 @@ rock-name
 To refresh the centralized files, run `just refresh`.
 
 For project-specific customizations, see [../README.md#customization](../README.md#customization).
+
+## Folder structure
+
+Each rock repository keeps one folder per maintained `major.minor` release
+line (e.g. `0.31/`, `0.32/`, `0.33/`), each with its own `rockcraft.yaml`.
+There is no `latest/` folder: the concrete version and upstream tag are
+recorded inside each folder's `rockcraft.yaml` (`version` +
+`parts.<name>.source-tag`), not in the folder name.
+
+- **New release lines are added manually**, roughly every six months, via
+  `just add-version <version>`. This resolves the newest real upstream tag on
+  the given `major.minor` line and fails if none exists.
+- **The scheduled `update` automation only patches existing folders** to the
+  newest upstream patch of their own line. It never creates a new folder or
+  jumps to a new minor, so onboarding a new release line stays a deliberate,
+  reviewed action.
+
+Set `source_repo` (upstream `org/repo`) in the repository's local `justfile`
+so `update`, `add-version`, and `govulncheck` don't need it passed explicitly.
+

--- a/blueprints/rocks/rocks.just
+++ b/blueprints/rocks/rocks.just
@@ -34,7 +34,7 @@ source_repo := ''
 # Push an OCI image to a local registry
 [private]
 @push-to-registry version=latest_version:
-  which -s docker || { echo "docker not found"; exit 1; }
+  which -s docker || { echo "× docker not found"; exit 1; }
   test -f "{{version}}"/*.rock || (cd "{{version}}" && rockcraft pack)
   echo "Pushing {{version}} to local docker registry"
   cd {{version}}; sudo rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false "oci-archive:$(ls *.rock)" docker-daemon:rockcraft-test:latest

--- a/blueprints/rocks/rocks.just
+++ b/blueprints/rocks/rocks.just
@@ -26,6 +26,11 @@ source_repo := ''
 @name:
   echo "{{rock_name}}"
 
+# Print the latest major.minor version
+[group("info")]
+@latest-version:
+  echo "{{latest_version}}"
+
 # Push an OCI image to a local registry
 [private]
 @push-to-registry version=latest_version:

--- a/blueprints/rocks/rocks.just
+++ b/blueprints/rocks/rocks.just
@@ -2,12 +2,18 @@
 set shell := ["bash", "-uc"]
 
 rock_name := `echo ${PWD##*/} | sed 's/-rock$//'`  # Get the rock name from the folder name
-latest_version := `find . -name rockcraft.yaml -printf '%h\n' | sort -V | tail -n1 | sed 's@./@@'`
+
+# Latest maintained version, i.e. the newest major.minor folder
+latest_version := `find . -maxdepth 1 -type d -regextype posix-extended -regex '\./[0-9]+\.[0-9]+' -printf '%f\n' | sort -V | tail -n1`
 
 # LTS end-of-life overrides. Override this variable in the local 'justfile'.
 # Define mappings from LTS minor versions to their EOL date in YYYY-MM-DD format.
 # Example: lts_releases := '{"2.14": "2026-12-31", "2.12": "2025-06-30"}'
 lts_releases := '{}'
+
+# Upstream project repository in 'org/repo' form. Override this variable in the local 'justfile'.
+# Example: source_repo := 'prometheus/alertmanager'
+source_repo := ''
 
 [private]
 @default:
@@ -15,31 +21,26 @@ lts_releases := '{}'
   echo "{{rock_name}}"
   echo "For help with a specific recipe, run: just --usage <recipe>"
 
-# Push an OCI image to a local registry
-[private]
-@push-to-registry version=latest_version:
-  which -s docker || { echo "docker not found"; exit 1; }
-  test -f "{{version}}/{{rock_name}}_{{version}}_amd64.rock" || rockcraft pack
-  echo "Pushing {{version}} to local docker registry"
-  cd {{version}}; sudo rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false "oci-archive:{{rock_name}}_{{version}}_amd64.rock" docker-daemon:rockcraft-test:latest
-  echo "✓ Rock pushed to local registry under 'rockcraft-test:latest'"
-
 # Print the rock name
 [group("info")]
 @name:
   echo "{{rock_name}}"
 
-# Print the latest rock version
-[group("info")]
-@latest-version:
-  echo "{{latest_version}}"
+# Push an OCI image to a local registry
+[private]
+@push-to-registry version=latest_version:
+  which -s docker || { echo "docker not found"; exit 1; }
+  test -f "{{version}}"/*.rock || (cd "{{version}}" && rockcraft pack)
+  echo "Pushing {{version}} to local docker registry"
+  cd {{version}}; sudo rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false "oci-archive:$(ls *.rock)" docker-daemon:rockcraft-test:latest
+  echo "✓ Rock pushed to local registry under 'rockcraft-test:latest'"
 
-# Pack a rock of a specific component and version
+# Pack a rock of a specific version (major.minor folder)
 [group("dev")]
 pack version=latest_version:
   cd "{{version}}" && rockcraft pack
 
-# `rockcraft clean` for a specific component and version
+# `rockcraft clean` for a specific version (major.minor folder)
 [group("dev")]
 clean version=latest_version:
   cd "{{version}}" && rockcraft clean
@@ -47,7 +48,7 @@ clean version=latest_version:
 # Run a rock and open a shell into it with `docker`
 [group("dev")]
 run version=latest_version: (push-to-registry version)
-  which -s dgoss || { echo "dgoss not found"; exit 1; }
+  which -s dgoss || { echo "× dgoss not found"; exit 1; }
   dgoss edit rockcraft-test:latest || true
 
 # Test a rock with `rockcraft test`
@@ -68,7 +69,7 @@ sbom version=latest_version:
   syft {{version}}/*.rock -o "spdx-json={{version}}/rock.sbom.json"
   @echo "✓ SBOM saved to {{version}}/rock.sbom.json"
 
-# Perform a securiy scan
+# Perform a security scan
 [group("security")]
 scan version=latest_version: (sbom version)
   uvx --from=trivy-py trivy sbom "{{version}}/rock.sbom.json"
@@ -76,14 +77,16 @@ scan version=latest_version: (sbom version)
 
 # Check whether CVEs affect the upstream project
 [group("security")]
-govulncheck source_repo version=latest_version:
+govulncheck version=latest_version:
   #!/usr/bin/env bash
   set -e
-  echo "Cloning {{source_repo}}"
+  [[ -z "{{source_repo}}" ]] && { echo "× Set 'source_repo' in the local justfile"; exit 1; }
+  # Resolve the real upstream tag from the rockcraft.yaml (folder name is not the version)
+  source_tag="$(yq -r '.parts.{{rock_name}}["source-tag"]' "{{version}}/rockcraft.yaml")"
+  echo "Cloning {{source_repo}} at $source_tag"
   which -s govulncheck || { echo "govulncheck not found; install it with:  go install golang.org/x/vuln/cmd/govulncheck@latest"; exit 1; }
   TMP_DIR="$(mktemp -d)"
-  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "{{version}}" --depth 1 2>/dev/null \
-    || gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "v{{version}}" --depth 1
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "$source_tag" --depth 1
   if [[ ! -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
     echo "⨯ {{source_repo}} is not a Go project (go.mod is missing)"
     exit 2
@@ -94,43 +97,75 @@ govulncheck source_repo version=latest_version:
   if [ "$vuln_exit" -ne 0 ]; then echo "⨯ 'govulncheck' failed"; exit "$vuln_exit"; fi
   echo "✓ 'govulncheck' passed."
 
-# Generate a rock for the latest version of the upstream project
-[arg("source_repo", help="Repository of the upstream project in 'org/repo' form")]
-[group("maintenance")]
-update source_repo release_tag="":
+# Print "<version> <tag>" for the newest upstream release on a major.minor line
+[private]
+@resolve-tag major_minor:
+  gh release list --repo {{source_repo}} --exclude-pre-releases --limit=200 --json tagName --jq '.[].tagName' \
+    | while read -r t; do \
+        v="${t#mimir-}"; v="${v#cmd/builder/v}"; v="${v#v}"; \
+        [[ "$(echo "$v" | grep -oP '^\d+\.\d+')" == "{{major_minor}}" ]] && echo "$v $t"; \
+      done \
+    | sort -V | tail -n1
+
+# Write a version + source-tag into a folder's rockcraft.yaml (and refresh Go build-snap)
+[private]
+write-version folder version tag:
   #!/usr/bin/env bash
   set -e
-  if [[ -z "{{release_tag}}" ]]; then
-    latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
-    echo "Latest release for {{source_repo}} is $latest_release"
-  else
-    latest_release="{{release_tag}}"
-    echo "Release version manually set to $latest_release"
-  fi
-  # Explicitly filter out prefixes for known rocks, so we can notice if a new rock has a different schema
-  version="${latest_release}"
-  version="${version#mimir-}"  # mimir
-  version="${version#cmd/builder/v}"  # opentelemetry-collector
-  version="${version#v}"  # Generic v- prefix
-  # If the version already exists as a rock, exit here
-  if [[ -d "$version" ]]; then echo "Folder $version already exists, nothing to do" && exit 0; fi
-  # Create the folder for the new version and update the rockcraft.yaml
-  cp -r "{{latest_version}}" "$version"
-  latest_release="$latest_release" version="$version" yq -i \
-    '.version = strenv(version) | .parts.{{rock_name}}["source-tag"] = strenv(latest_release)' \
-    "./$version/rockcraft.yaml"
-  # Automatically update build tools (go) from the upstream repository
+  file="{{folder}}/rockcraft.yaml"
+  version="{{version}}" tag="{{tag}}" yq -i \
+    '.version = strenv(version) | .parts.{{rock_name}}["source-tag"] = strenv(tag)' \
+    "$file"
   TMP_DIR="$(mktemp -d)"
-  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "$latest_release" --depth 1
-  # If it's a Go project, update the Go version
-  if [[ -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
-    go_snap_version="$(grep -Po '^go \K(\S+)' "$TMP_DIR/{{source_repo}}/go.mod" | sed -E 's/([0-9]+\.[0-9]+).*/\1/')"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/src" -- --branch "{{tag}}" --depth 1 2>/dev/null || true
+  if [[ -f "$TMP_DIR/src/go.mod" ]]; then
+    go_snap_version="$(grep -Po '^go \K(\S+)' "$TMP_DIR/src/go.mod" | sed -E 's/([0-9]+\.[0-9]+).*/\1/')"
     go_snap_version="$go_snap_version" yq -i \
       '(.parts.{{rock_name}}.build-snaps[] | select(test("^go/"))) = "go/"+strenv(go_snap_version)+"/candidate"' \
-      "./$version/rockcraft.yaml"
+      "$file"
   fi
   rm -rf "$TMP_DIR"
-  echo "✓ Created rock for version $version"
+
+# Create a new major.minor folder, resolving the newest real upstream tag on that line
+[group("maintenance")]
+add-version version:
+  #!/usr/bin/env bash
+  set -e
+  [[ -z "{{source_repo}}" ]] && { echo "× Set 'source_repo' in the local justfile"; exit 1; }
+  # Normalize the requested version to a major.minor line
+  requested="{{version}}"
+  requested="${requested#mimir-}"; requested="${requested#cmd/builder/v}"; requested="${requested#v}"
+  major_minor="$(echo "$requested" | grep -oP '^\d+\.\d+')"
+  [[ -z "$major_minor" ]] && { echo "× could not parse a major.minor from '{{version}}'"; exit 1; }
+  [[ -d "$major_minor" ]] && { echo "→ $major_minor/ already exists, nothing to do"; exit 0; }
+  # Resolve the newest upstream tag on this line before touching anything
+  read -r version tag < <(just resolve-tag "$major_minor")
+  [[ -z "$version" ]] && { echo "× no upstream release found for {{source_repo}} on the $major_minor line"; exit 1; }
+  # Seed from the newest existing minor folder, then pin the resolved version
+  template="{{latest_version}}"
+  [[ -z "$template" ]] && { echo "× no existing X.Y folder to copy from"; exit 1; }
+  echo "Seeding $major_minor/ from $template/ ..."
+  cp -r "$template" "$major_minor"
+  just write-version "$major_minor" "$version" "$tag"
+  echo "✓ Created $major_minor/ at $version (source-tag $tag)"
+
+# Patch all existing major.minor folders to the newest upstream patch version
+[group("maintenance")]
+update:
+  #!/usr/bin/env bash
+  set -e
+  [[ -z "{{source_repo}}" ]] && { echo "× Set 'source_repo' in the local justfile"; exit 1; }
+  updated_folders=""
+  for folder in $(find . -maxdepth 1 -type d -regextype posix-extended -regex '\./[0-9]+\.[0-9]+' -printf '%f\n' | sort -V); do
+    read -r version tag < <(just resolve-tag "$folder")
+    if [[ -z "$version" ]]; then echo "→ no upstream patch found for $folder, skipping"; continue; fi
+    current="$(yq -r '.version' "$folder/rockcraft.yaml")"
+    if [[ "$current" == "$version" ]]; then echo "→ $folder already at $version"; continue; fi
+    echo "Updating $folder: $current → $version (source-tag $tag)"
+    just write-version "$folder" "$version" "$tag"
+    updated_folders="$updated_folders $folder"
+  done
+  if [[ -n "$updated_folders" ]]; then echo; echo "✓ Versions updated"; fi
 
 # Fetch centralized files from canonical/observability
 [group("maintenance")]
@@ -168,21 +203,23 @@ release-oci-factory version=latest_version support="minor" risk="stable":
   if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user observability-noctua-bot"; exit 1; fi
   if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
   repository="$(git remote get-url origin | sed -E 's#(git@[^:]+:|https?://[^/]+/)##; s/\.git$//')"
+  # Read the real semver from the rockcraft.yaml (folder name is 'X.Y')
+  rock_version="$(yq -r '.version' "{{version}}/rockcraft.yaml")"
   # Extract the base from the rockcraft.yaml (e.g. "ubuntu@24.04" -> "24.04")
   # For bare-based rocks, fall back to build-base (e.g. "ubuntu@26.04" -> "26.04")
   rock_base="$(yq -r '.base' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
   if [[ "$rock_base" == "bare" ]]; then
     rock_base="$(yq -r '.["build-base"]' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
   fi
-  echo "Detected base: $rock_base"
+  echo "Detected version: $rock_version, base: $rock_base"
   # Clone the oci-factory and push data to it
   gh repo sync --force observability-noctua-bot/oci-factory
   TMP_DIR="$(mktemp -d)"
   git clone https://github.com/observability-noctua-bot/oci-factory "$TMP_DIR/oci-factory"
   echo "✓ Cloned observability-noctua-bot/oci-factory"
   # Build the OCI Factory manifest
-  # Check if this version has a custom EOL in lts_releases
-  minor_version="$(echo "{{version}}" | grep -oP '^\d+\.\d+')"
+  # Check if this version has a custom EOL in lts_releases (keyed by major.minor)
+  minor_version="$(echo "$rock_version" | grep -oP '^\d+\.\d+')"
   eol_date="$(echo '{{lts_releases}}' | jq -r --arg v "$minor_version" '.[$v] // empty')"
   eol_flag=""
   if [[ -n "$eol_date" ]]; then
@@ -197,7 +234,7 @@ release-oci-factory version=latest_version support="minor" risk="stable":
     --base="$rock_base" \
     --support="{{support}}" \
     --risk="{{risk}}" \
-    --version="{{version}}" \
+    --version="$rock_version" \
     $eol_flag \
     | tee "$manifest_file"
   echo; echo "✓ OCI Factory manifest generated"


### PR DESCRIPTION
## Why

Rock repositories currently keep one folder per full semver release (`0.32.1/`, `0.32.2/`, `0.33.0/`, ...), which accumulates indefinitely and makes it unclear which release lines are actually supported. This mirrors the layout already used by the Observability snaps (e.g. `grafana-agent-snap`): only `major.minor` folders are kept, each tracking its own patch releases.

Prototyped end-to-end against `alertmanager-rock`: canonical/alertmanager-rock#110

## What changed

- `blueprints/rocks/rocks.just`:
  - `latest_version` now resolves the newest `X.Y` folder instead of the newest full-semver folder. There is intentionally **no `latest/` folder** — every maintained minor is a first-class release line.
  - Added a `source_repo` variable (set via each repo's local `justfile`) so `update`, `add-version`, and `govulncheck` don't need it passed as an arg.
  - Removed the `latest-version` recipe (folder name is no longer meaningful as "the" version).
  - New `add-version <version>` recipe: manually onboard a new `major.minor` folder by resolving the newest real upstream tag on that line. Fails if no matching upstream release exists. Meant to be run roughly every six months, not on a schedule.
  - Rewrote `update`: now iterates existing `X.Y` folders only and bumps each to the newest upstream patch of its own line. **Never creates a new folder or jumps to a new minor** — onboarding stays a deliberate action via `add-version`.
  - Extracted two small private recipes (`resolve-tag`, `write-version`) shared by `add-version` and `update` to avoid duplicating tag-resolution/yaml-writing logic.
  - `release-oci-factory`, `govulncheck`, `push-to-registry`, `release-ghcr` now read the real version/tag from `rockcraft.yaml` instead of assuming the folder name is the version.
- `blueprints/rocks/README.md`: documented the new folder structure and the manual-onboarding / automated-patching split.
- `.github/workflows/rock-update.yaml`: now calls `just update` (patch-only) and opens a PR describing which `major.minor` folders were bumped, instead of assuming a brand-new folder was created.
- `.github/workflows/rock-add-version.yaml` (**new**): manually dispatched workflow pairing with the `add-version` recipe, so a maintainer can onboard a new release line from the GitHub UI with a required `version` input.
- `.github/workflows/rock-release-dev.yaml`: replaced the removed `just latest-version` call with `just --evaluate latest_version`.

## Required changes in individual rock repositories

Repos that adopt this blueprint need to:

1. Run `just refresh` to pull the updated `rocks.just` (and `spread.yaml` if changed).
2. Restructure existing release folders into `major.minor` folders (e.g. consolidate `0.33.0/` into `0.33/`), removing folders for release lines no longer supported. There is no `latest/` folder.
3. Add `source_repo := 'org/repo'` to the local `justfile`.
4. No changes needed to the existing `update.yaml` / `release-oci-factory.yaml` / `pull-request.yaml` workflow files — their reusable workflow inputs are unchanged.

See canonical/alertmanager-rock#110 for a complete worked example of steps 2-3.