### PR TITLE
Remove per-line EOL overrides from the rocks blueprint

### DIFF
--- a/blueprints/rocks/rocks.just
+++ b/blueprints/rocks/rocks.just
@@ -6,11 +6,6 @@ rock_name := `echo ${PWD##*/} | sed 's/-rock$//'`  # Get the rock name from the 
 # Latest maintained version, i.e. the newest major.minor folder
 latest_version := `find . -maxdepth 1 -type d -regextype posix-extended -regex '\./[0-9]+\.[0-9]+' -printf '%f\n' | sort -V | tail -n1`
 
-# LTS end-of-life overrides. Override this variable in the local 'justfile'.
-# Define mappings from LTS minor versions to their EOL date in YYYY-MM-DD format.
-# Example: lts_releases := '{"2.14": "2026-12-31", "2.12": "2025-06-30"}'
-lts_releases := '{}'
-
 # Upstream project repository in 'org/repo' form. Override this variable in the local 'justfile'.
 # Example: source_repo := 'prometheus/alertmanager'
 source_repo := ''
@@ -222,15 +217,6 @@ release-oci-factory version=latest_version support="minor" risk="stable":
   TMP_DIR="$(mktemp -d)"
   git clone https://github.com/observability-noctua-bot/oci-factory "$TMP_DIR/oci-factory"
   echo "✓ Cloned observability-noctua-bot/oci-factory"
-  # Build the OCI Factory manifest
-  # Check if this version has a custom EOL in lts_releases (keyed by major.minor)
-  minor_version="$(echo "$rock_version" | grep -oP '^\d+\.\d+')"
-  eol_date="$(echo '{{lts_releases}}' | jq -r --arg v "$minor_version" '.[$v] // empty')"
-  eol_flag=""
-  if [[ -n "$eol_date" ]]; then
-    eol_flag="--eol=$eol_date"
-    echo "LTS release detected: EOL set to $eol_date"
-  fi
   echo "Building the OCI Factory manifest..."; echo
   manifest_file="$TMP_DIR/oci-factory/oci/{{rock_name}}/image.yaml"
   uvx --from=git+https://github.com/lucabello/noctua noctua rock manifest \
@@ -240,7 +226,6 @@ release-oci-factory version=latest_version support="minor" risk="stable":
     --support="{{support}}" \
     --risk="{{risk}}" \
     --version="$rock_version" \
-    $eol_flag \
     | tee "$manifest_file"
   echo; echo "✓ OCI Factory manifest generated"
   # If there's nothing to upload, exit early


### PR DESCRIPTION
## Why

The `lts_releases` variable let individual rock repos override the OCI Factory `--eol` date per `major.minor` release line via their local `justfile`. We're moving end-of-life / LTS tracking to a central manifest instead of scattering it across each repo's justfile.

Prototyped in canonical/alertmanager-rock (branch `feat/restructure`).

## What changed

- `blueprints/rocks/rocks.just`: removed the `lts_releases` variable and the EOL lookup/`--eol` flag in `release-oci-factory`. The recipe now lets `noctua rock manifest` use its own default lifecycle.
- No README changes needed: `blueprints/rocks/README.md` never documented `lts_releases`.

## Required changes in individual rock repositories

- Run `just refresh` to pull the updated `rocks.just`.
- Remove any `lts_releases := '...'` (or `releases := '...'`) override from the local `justfile`.