### PR TITLE
feat(ci): add fleet-wide charm security scan report workflow

### DIFF
--- a/.github/workflows/_local-charm-scan.yaml
+++ b/.github/workflows/_local-charm-scan.yaml
@@ -20,25 +20,38 @@ jobs:
         id: matrix
         run: |
           set -euo pipefail
+          # Grouped by repo+branch (not by charm) so a repo hosting several charms
+          # at the same track (litmus-operators, loki-operators, mimir-operators,
+          # pyroscope-operators, tempo-operators, ...) is only cloned once instead
+          # of once per charm that lives in it.
           matrix="$(yq -o=json manifest.yaml | jq -c '
             [.artifacts.charms[]
               | .name as $charm | .repo as $repo | .path as $path
               | .releases[]?
               | {
-                  charm: $charm,
                   repo: $repo,
+                  branch: .branch,
+                  charm: $charm,
                   path: $path,
                   release: .name,
-                  branch: .branch,
                   cycle: (.cycle | tostring),
                   lts: (.support.lts // false)
                 }
-            ]')"
-          echo "Found $(echo "$matrix" | jq length) charm releases to scan"
+            ]
+            | group_by(.repo + "@" + .branch)
+            | map({
+                repo: .[0].repo,
+                branch: .[0].branch,
+                charms: map({charm, path, release, cycle, lts})
+              })
+          ')"
+          releases="$(echo "$matrix" | jq '[.[].charms[]] | length')"
+          clones="$(echo "$matrix" | jq length)"
+          echo "Found $releases charm releases across $clones repo+branch clones"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   scan:
-    name: Scan ${{ matrix.charm }} (${{ matrix.release }})
+    name: Scan ${{ matrix.repo }}@${{ matrix.branch }}
     needs: build-matrix
     runs-on: ubuntu-latest
     strategy:
@@ -63,64 +76,76 @@ jobs:
         run: |
           set -o pipefail
           git clone --depth=1 --branch "$BRANCH" "https://github.com/${REPO}.git" charm-checkout \
-            2>&1 | tee "$RUNNER_TEMP/scan-output.log"
+            2>&1 | tee "$RUNNER_TEMP/clone-output.log"
 
-      - name: Run security scan
-        id: scan
-        if: steps.checkout.outcome == 'success'
-        continue-on-error: true
-        working-directory: charm-checkout/${{ matrix.path }}
-        run: |
-          set -o pipefail
-          just scan 2>&1 | tee "$RUNNER_TEMP/scan-output.log"
-
-      - name: Record result
-        id: result
+      # One clone can back several charms (see the grouping in build-matrix), so
+      # this loops `just scan` over each of them and records one result per charm
+      # - a shared clone failure is recorded against all of them, each with its
+      # own status otherwise.
+      - name: Run scans and record results
+        id: scans
         if: always()
         env:
-          CHARM: ${{ matrix.charm }}
-          RELEASE: ${{ matrix.release }}
-          CYCLE: ${{ matrix.cycle }}
-          LTS: ${{ matrix.lts }}
+          CHARMS_JSON: ${{ toJSON(matrix.charms) }}
           REPO: ${{ matrix.repo }}
           BRANCH: ${{ matrix.branch }}
           CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
-          SCAN_OUTCOME: ${{ steps.scan.outcome }}
         run: |
-          set -euo pipefail
-          if [[ "$CHECKOUT_OUTCOME" != "success" ]]; then
-            status="checkout-failed"
-          elif [[ "$SCAN_OUTCOME" == "failure" ]]; then
-            status="vulnerabilities-found"
-          else
-            status="pass"
-          fi
+          set -uo pipefail
+          mkdir -p "$RUNNER_TEMP/results"
+          clone_log="$RUNNER_TEMP/clone-output.log"
+          [[ -f "$clone_log" ]] || echo "(no output captured)" > "$clone_log"
 
-          log_file="$RUNNER_TEMP/scan-output.log"
-          [[ -f "$log_file" ]] || echo "(no output captured)" > "$log_file"
+          while read -r entry; do
+            charm="$(jq -r '.charm' <<<"$entry")"
+            path="$(jq -r '.path' <<<"$entry")"
+            release="$(jq -r '.release' <<<"$entry")"
+            cycle="$(jq -r '.cycle' <<<"$entry")"
+            lts="$(jq -r '.lts' <<<"$entry")"
 
-          mkdir -p "$RUNNER_TEMP/result"
-          jq -n \
-            --arg charm "$CHARM" \
-            --arg release "$RELEASE" \
-            --arg cycle "$CYCLE" \
-            --argjson lts "$LTS" \
-            --arg repo "$REPO" \
-            --arg branch "$BRANCH" \
-            --arg status "$status" \
-            --rawfile log "$log_file" \
-            '{charm:$charm, release:$release, cycle:$cycle, lts:$lts, repo:$repo, branch:$branch, status:$status, log:$log}' \
-            > "$RUNNER_TEMP/result/result.json"
+            log_file="$RUNNER_TEMP/scan-${charm}.log"
 
-      - name: Upload scan result
+            if [[ "$CHECKOUT_OUTCOME" != "success" ]]; then
+              status="checkout-failed"
+              cp "$clone_log" "$log_file"
+            elif (cd "charm-checkout/$path" && just scan) >"$log_file" 2>&1; then
+              status="pass"
+            else
+              status="vulnerabilities-found"
+            fi
+
+            jq -n \
+              --arg charm "$charm" \
+              --arg release "$release" \
+              --arg cycle "$cycle" \
+              --argjson lts "$lts" \
+              --arg repo "$REPO" \
+              --arg branch "$BRANCH" \
+              --arg status "$status" \
+              --rawfile log "$log_file" \
+              '{charm:$charm, release:$release, cycle:$cycle, lts:$lts, repo:$repo, branch:$branch, status:$status, log:$log}' \
+              > "$RUNNER_TEMP/results/${charm}-${release}.json"
+          done < <(jq -c '.[]' <<<"$CHARMS_JSON")
+
+      - name: Compute artifact name
+        if: always()
+        id: artifact-name
+        env:
+          REPO: ${{ matrix.repo }}
+          BRANCH: ${{ matrix.branch }}
+        run: |
+          safe="${REPO//\//-}-${BRANCH//\//-}"
+          echo "name=scan-results-${safe}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload scan results
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: scan-result-${{ matrix.charm }}-${{ matrix.release }}
-          path: ${{ runner.temp }}/result/result.json
+          name: ${{ steps.artifact-name.outputs.name }}
+          path: ${{ runner.temp }}/results/
           if-no-files-found: error
 
-      # Runs last so the result is always recorded and uploaded first: a missing
+      # Runs last so results are always recorded and uploaded first: a missing
       # branch (or any other clone problem) should fail this job and the overall
       # run, but vulnerabilities found by `just scan` should not.
       - name: Fail on checkout error
@@ -138,7 +163,7 @@ jobs:
       - name: Download scan results
         uses: actions/download-artifact@v7
         with:
-          pattern: scan-result-*
+          pattern: scan-results-*
           path: results
 
       - name: Build report
@@ -150,7 +175,7 @@ jobs:
           import os
 
           results = []
-          for path in glob.glob("results/*/result.json"):
+          for path in glob.glob("results/*/*.json"):
               with open(path) as f:
                   results.append(json.load(f))
 

--- a/.github/workflows/_local-charm-scan.yaml
+++ b/.github/workflows/_local-charm-scan.yaml
@@ -14,36 +14,15 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install dependencies
-        run: sudo snap install yq
+        run: |
+          sudo snap install just --classic
+          sudo snap install yq
 
       - name: Generate matrix from manifest
         id: matrix
         run: |
           set -euo pipefail
-          # Grouped by repo only (not repo+branch), so a repo is cloned exactly
-          # once regardless of how many charms or active release branches it
-          # hosts. Multiple branches of the same repo are checked out one after
-          # another from that single clone (see the `scan` job below).
-          matrix="$(yq -o=json manifest.yaml | jq -c '
-            [.artifacts.charms[]
-              | .name as $charm | .repo as $repo | .path as $path
-              | .releases[]?
-              | {
-                  repo: $repo,
-                  branch: .branch,
-                  charm: $charm,
-                  path: $path,
-                  release: .name,
-                  cycle: (.cycle | tostring),
-                  lts: (.support.lts // false)
-                }
-            ]
-            | group_by(.repo)
-            | map({
-                repo: .[0].repo,
-                charms: map({charm, path, release, branch, cycle, lts})
-              })
-          ')"
+          matrix="$(just list-scan-matrix)"
           releases="$(echo "$matrix" | jq '[.[].charms[]] | length')"
           repos="$(echo "$matrix" | jq length)"
           echo "Found $releases charm releases across $repos repo clones"
@@ -58,84 +37,20 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Install dependencies
         run: |
           sudo snap install just --classic
+          sudo snap install yq
           sudo snap install astral-uv --classic
 
-      # One clone can back several charms and several release branches (see the
-      # grouping in build-matrix). `--depth=1 --no-single-branch` fetches shallow
-      # history for *every* branch in a single network round trip, so each branch
-      # below is then just a local `git checkout` - no re-cloning per branch, and
-      # a bad branch name (missing from manifest.yaml) fails locally and cheaply.
-      - name: Run scans and record results
-        id: scans
-        env:
-          CHARMS_JSON: ${{ toJSON(matrix.charms) }}
-          REPO: ${{ matrix.repo }}
-        run: |
-          set -uo pipefail
-          mkdir -p "$RUNNER_TEMP/results"
-
-          record_result() {
-            # args: charm release cycle lts branch status log_file
-            jq -n \
-              --arg charm "$1" --arg release "$2" --arg cycle "$3" \
-              --argjson lts "$4" --arg repo "$REPO" --arg branch "$5" \
-              --arg status "$6" --rawfile log "$7" \
-              '{charm:$charm, release:$release, cycle:$cycle, lts:$lts, repo:$repo, branch:$branch, status:$status, log:$log}' \
-              > "$RUNNER_TEMP/results/$1-$2.json"
-          }
-
-          any_failed=0
-          clone_log="$RUNNER_TEMP/clone-output.log"
-          if git clone --quiet --no-checkout --depth=1 --no-single-branch \
-               "https://github.com/${REPO}.git" charm-checkout >"$clone_log" 2>&1; then
-            cd charm-checkout
-
-            for branch in $(jq -r '[.[].branch] | unique | .[]' <<<"$CHARMS_JSON"); do
-              branch_log="$RUNNER_TEMP/checkout-${branch//\//-}.log"
-              if git checkout --quiet -B "$branch" "origin/$branch" >"$branch_log" 2>&1; then
-                branch_ok=1
-              else
-                branch_ok=0
-                any_failed=1
-              fi
-
-              while read -r entry; do
-                charm="$(jq -r '.charm' <<<"$entry")"
-                path="$(jq -r '.path' <<<"$entry")"
-                release="$(jq -r '.release' <<<"$entry")"
-                cycle="$(jq -r '.cycle' <<<"$entry")"
-                lts="$(jq -r '.lts' <<<"$entry")"
-
-                log_file="$RUNNER_TEMP/scan-${charm}.log"
-                if [[ "$branch_ok" -ne 1 ]]; then
-                  status="checkout-failed"
-                  cp "$branch_log" "$log_file"
-                elif (cd "$path" && just scan) >"$log_file" 2>&1; then
-                  status="pass"
-                else
-                  status="vulnerabilities-found"
-                fi
-                record_result "$charm" "$release" "$cycle" "$lts" "$branch" "$status" "$log_file"
-              done < <(jq -c --arg b "$branch" '.[] | select(.branch == $b)' <<<"$CHARMS_JSON")
-            done
-          else
-            # The repo itself couldn't be cloned at all - every charm/branch it
-            # would have backed is reported as checkout-failed against this one log.
-            any_failed=1
-            while read -r entry; do
-              charm="$(jq -r '.charm' <<<"$entry")"
-              release="$(jq -r '.release' <<<"$entry")"
-              cycle="$(jq -r '.cycle' <<<"$entry")"
-              lts="$(jq -r '.lts' <<<"$entry")"
-              branch="$(jq -r '.branch' <<<"$entry")"
-              record_result "$charm" "$release" "$cycle" "$lts" "$branch" "checkout-failed" "$clone_log"
-            done < <(jq -c '.[]' <<<"$CHARMS_JSON")
-          fi
-
-          echo "any-failed=$any_failed" >> "$GITHUB_OUTPUT"
+      # All the cloning/checkout/scanning logic lives in `just scan-repo` (see
+      # justfile) so it can be run and debugged locally the same way CI runs it,
+      # e.g.: just scan-repo canonical/litmus-operators
+      - name: Scan ${{ matrix.repo }}
+        run: just scan-repo "${{ matrix.repo }}"
 
       - name: Compute artifact name
         if: always()
@@ -152,15 +67,6 @@ jobs:
           name: ${{ steps.artifact-name.outputs.name }}
           path: ${{ runner.temp }}/results/
           if-no-files-found: error
-
-      # Runs last so results are always recorded and uploaded first: a missing
-      # branch (or any other clone/checkout problem) should fail this job and the
-      # overall run, but vulnerabilities found by `just scan` should not.
-      - name: Fail on checkout error
-        if: steps.scans.outputs.any-failed == '1'
-        run: |
-          echo "::error::One or more branches of ${{ matrix.repo }} failed to check out - see the scan step above for details."
-          exit 1
 
   report:
     name: Publish report

--- a/.github/workflows/_local-charm-scan.yaml
+++ b/.github/workflows/_local-charm-scan.yaml
@@ -19,9 +19,9 @@ jobs:
 
       # All the cloning/checkout/scanning logic lives in `security.just` so it
       # can be run and debugged locally the same way CI runs it, e.g.:
-      # just security::scan-fleet
+      # just security::scan-charms
       - name: Scan every charm in manifest.yaml
-        run: just security::scan-fleet
+        run: just security::scan-charms
 
       - name: Build report
         if: always()

--- a/.github/workflows/_local-charm-scan.yaml
+++ b/.github/workflows/_local-charm-scan.yaml
@@ -20,10 +20,10 @@ jobs:
         id: matrix
         run: |
           set -euo pipefail
-          # Grouped by repo+branch (not by charm) so a repo hosting several charms
-          # at the same track (litmus-operators, loki-operators, mimir-operators,
-          # pyroscope-operators, tempo-operators, ...) is only cloned once instead
-          # of once per charm that lives in it.
+          # Grouped by repo only (not repo+branch), so a repo is cloned exactly
+          # once regardless of how many charms or active release branches it
+          # hosts. Multiple branches of the same repo are checked out one after
+          # another from that single clone (see the `scan` job below).
           matrix="$(yq -o=json manifest.yaml | jq -c '
             [.artifacts.charms[]
               | .name as $charm | .repo as $repo | .path as $path
@@ -38,20 +38,19 @@ jobs:
                   lts: (.support.lts // false)
                 }
             ]
-            | group_by(.repo + "@" + .branch)
+            | group_by(.repo)
             | map({
                 repo: .[0].repo,
-                branch: .[0].branch,
-                charms: map({charm, path, release, cycle, lts})
+                charms: map({charm, path, release, branch, cycle, lts})
               })
           ')"
           releases="$(echo "$matrix" | jq '[.[].charms[]] | length')"
-          clones="$(echo "$matrix" | jq length)"
-          echo "Found $releases charm releases across $clones repo+branch clones"
+          repos="$(echo "$matrix" | jq length)"
+          echo "Found $releases charm releases across $repos repo clones"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   scan:
-    name: Scan ${{ matrix.repo }}@${{ matrix.branch }}
+    name: Scan ${{ matrix.repo }}
     needs: build-matrix
     runs-on: ubuntu-latest
     strategy:
@@ -64,78 +63,87 @@ jobs:
           sudo snap install just --classic
           sudo snap install astral-uv --classic
 
-      # A plain `git clone` (rather than actions/checkout) is used here so that a
-      # missing branch's own error output can be captured into the same report the
-      # scan output goes into, instead of only being visible in this job's log.
-      - name: Clone ${{ matrix.repo }}@${{ matrix.branch }}
-        id: checkout
-        continue-on-error: true
-        env:
-          REPO: ${{ matrix.repo }}
-          BRANCH: ${{ matrix.branch }}
-        run: |
-          set -o pipefail
-          git clone --depth=1 --branch "$BRANCH" "https://github.com/${REPO}.git" charm-checkout \
-            2>&1 | tee "$RUNNER_TEMP/clone-output.log"
-
-      # One clone can back several charms (see the grouping in build-matrix), so
-      # this loops `just scan` over each of them and records one result per charm
-      # - a shared clone failure is recorded against all of them, each with its
-      # own status otherwise.
+      # One clone can back several charms and several release branches (see the
+      # grouping in build-matrix). `--depth=1 --no-single-branch` fetches shallow
+      # history for *every* branch in a single network round trip, so each branch
+      # below is then just a local `git checkout` - no re-cloning per branch, and
+      # a bad branch name (missing from manifest.yaml) fails locally and cheaply.
       - name: Run scans and record results
         id: scans
-        if: always()
         env:
           CHARMS_JSON: ${{ toJSON(matrix.charms) }}
           REPO: ${{ matrix.repo }}
-          BRANCH: ${{ matrix.branch }}
-          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
         run: |
           set -uo pipefail
           mkdir -p "$RUNNER_TEMP/results"
-          clone_log="$RUNNER_TEMP/clone-output.log"
-          [[ -f "$clone_log" ]] || echo "(no output captured)" > "$clone_log"
 
-          while read -r entry; do
-            charm="$(jq -r '.charm' <<<"$entry")"
-            path="$(jq -r '.path' <<<"$entry")"
-            release="$(jq -r '.release' <<<"$entry")"
-            cycle="$(jq -r '.cycle' <<<"$entry")"
-            lts="$(jq -r '.lts' <<<"$entry")"
-
-            log_file="$RUNNER_TEMP/scan-${charm}.log"
-
-            if [[ "$CHECKOUT_OUTCOME" != "success" ]]; then
-              status="checkout-failed"
-              cp "$clone_log" "$log_file"
-            elif (cd "charm-checkout/$path" && just scan) >"$log_file" 2>&1; then
-              status="pass"
-            else
-              status="vulnerabilities-found"
-            fi
-
+          record_result() {
+            # args: charm release cycle lts branch status log_file
             jq -n \
-              --arg charm "$charm" \
-              --arg release "$release" \
-              --arg cycle "$cycle" \
-              --argjson lts "$lts" \
-              --arg repo "$REPO" \
-              --arg branch "$BRANCH" \
-              --arg status "$status" \
-              --rawfile log "$log_file" \
+              --arg charm "$1" --arg release "$2" --arg cycle "$3" \
+              --argjson lts "$4" --arg repo "$REPO" --arg branch "$5" \
+              --arg status "$6" --rawfile log "$7" \
               '{charm:$charm, release:$release, cycle:$cycle, lts:$lts, repo:$repo, branch:$branch, status:$status, log:$log}' \
-              > "$RUNNER_TEMP/results/${charm}-${release}.json"
-          done < <(jq -c '.[]' <<<"$CHARMS_JSON")
+              > "$RUNNER_TEMP/results/$1-$2.json"
+          }
+
+          any_failed=0
+          clone_log="$RUNNER_TEMP/clone-output.log"
+          if git clone --quiet --no-checkout --depth=1 --no-single-branch \
+               "https://github.com/${REPO}.git" charm-checkout >"$clone_log" 2>&1; then
+            cd charm-checkout
+
+            for branch in $(jq -r '[.[].branch] | unique | .[]' <<<"$CHARMS_JSON"); do
+              branch_log="$RUNNER_TEMP/checkout-${branch//\//-}.log"
+              if git checkout --quiet -B "$branch" "origin/$branch" >"$branch_log" 2>&1; then
+                branch_ok=1
+              else
+                branch_ok=0
+                any_failed=1
+              fi
+
+              while read -r entry; do
+                charm="$(jq -r '.charm' <<<"$entry")"
+                path="$(jq -r '.path' <<<"$entry")"
+                release="$(jq -r '.release' <<<"$entry")"
+                cycle="$(jq -r '.cycle' <<<"$entry")"
+                lts="$(jq -r '.lts' <<<"$entry")"
+
+                log_file="$RUNNER_TEMP/scan-${charm}.log"
+                if [[ "$branch_ok" -ne 1 ]]; then
+                  status="checkout-failed"
+                  cp "$branch_log" "$log_file"
+                elif (cd "$path" && just scan) >"$log_file" 2>&1; then
+                  status="pass"
+                else
+                  status="vulnerabilities-found"
+                fi
+                record_result "$charm" "$release" "$cycle" "$lts" "$branch" "$status" "$log_file"
+              done < <(jq -c --arg b "$branch" '.[] | select(.branch == $b)' <<<"$CHARMS_JSON")
+            done
+          else
+            # The repo itself couldn't be cloned at all - every charm/branch it
+            # would have backed is reported as checkout-failed against this one log.
+            any_failed=1
+            while read -r entry; do
+              charm="$(jq -r '.charm' <<<"$entry")"
+              release="$(jq -r '.release' <<<"$entry")"
+              cycle="$(jq -r '.cycle' <<<"$entry")"
+              lts="$(jq -r '.lts' <<<"$entry")"
+              branch="$(jq -r '.branch' <<<"$entry")"
+              record_result "$charm" "$release" "$cycle" "$lts" "$branch" "checkout-failed" "$clone_log"
+            done < <(jq -c '.[]' <<<"$CHARMS_JSON")
+          fi
+
+          echo "any-failed=$any_failed" >> "$GITHUB_OUTPUT"
 
       - name: Compute artifact name
         if: always()
         id: artifact-name
         env:
           REPO: ${{ matrix.repo }}
-          BRANCH: ${{ matrix.branch }}
         run: |
-          safe="${REPO//\//-}-${BRANCH//\//-}"
-          echo "name=scan-results-${safe}" >> "$GITHUB_OUTPUT"
+          echo "name=scan-results-${REPO//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Upload scan results
         if: always()
@@ -146,12 +154,12 @@ jobs:
           if-no-files-found: error
 
       # Runs last so results are always recorded and uploaded first: a missing
-      # branch (or any other clone problem) should fail this job and the overall
-      # run, but vulnerabilities found by `just scan` should not.
+      # branch (or any other clone/checkout problem) should fail this job and the
+      # overall run, but vulnerabilities found by `just scan` should not.
       - name: Fail on checkout error
-        if: steps.checkout.outcome == 'failure'
+        if: steps.scans.outputs.any-failed == '1'
         run: |
-          echo "::error::Failed to clone ${{ matrix.repo }}@${{ matrix.branch }} - see the 'Clone' step above for details."
+          echo "::error::One or more branches of ${{ matrix.repo }} failed to check out - see the scan step above for details."
           exit 1
 
   report:

--- a/.github/workflows/_local-charm-scan.yaml
+++ b/.github/workflows/_local-charm-scan.yaml
@@ -4,38 +4,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-matrix:
-    name: Build charm release matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: |
-          sudo snap install just --classic
-          sudo snap install yq
-
-      - name: Generate matrix from manifest
-        id: matrix
-        run: |
-          set -euo pipefail
-          matrix="$(just security::scan-matrix)"
-          releases="$(echo "$matrix" | jq '[.[].charms[]] | length')"
-          repos="$(echo "$matrix" | jq length)"
-          echo "Found $releases charm releases across $repos repo clones"
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-
   scan:
-    name: Scan ${{ matrix.repo }}
-    needs: build-matrix
+    name: Scan fleet
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -48,43 +19,10 @@ jobs:
 
       # All the cloning/checkout/scanning logic lives in `security.just` so it
       # can be run and debugged locally the same way CI runs it, e.g.:
-      # just security::scan-repo canonical/litmus-operators
-      - name: Scan ${{ matrix.repo }}
-        run: just security::scan-repo "${{ matrix.repo }}"
-
-      - name: Compute artifact name
-        if: always()
-        id: artifact-name
-        env:
-          REPO: ${{ matrix.repo }}
-        run: |
-          echo "name=scan-results-${REPO//\//-}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload scan results
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ steps.artifact-name.outputs.name }}
-          path: ${{ runner.temp }}/results/
-          if-no-files-found: error
-
-  report:
-    name: Publish report
-    needs: scan
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: sudo snap install just --classic
-
-      - name: Download scan results
-        uses: actions/download-artifact@v7
-        with:
-          pattern: scan-results-*
-          path: results
+      # just security::scan-fleet
+      - name: Scan every charm in manifest.yaml
+        run: just security::scan-fleet
 
       - name: Build report
-        run: just security::build-report results >> "$GITHUB_STEP_SUMMARY"
+        if: always()
+        run: just security::build-report "$RUNNER_TEMP/results" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/_local-charm-scan.yaml
+++ b/.github/workflows/_local-charm-scan.yaml
@@ -1,0 +1,221 @@
+name: Charm Security Scan (fleet-wide)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-matrix:
+    name: Build charm release matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: sudo snap install yq
+
+      - name: Generate matrix from manifest
+        id: matrix
+        run: |
+          set -euo pipefail
+          matrix="$(yq -o=json manifest.yaml | jq -c '
+            [.artifacts.charms[]
+              | .name as $charm | .repo as $repo | .path as $path
+              | .releases[]?
+              | {
+                  charm: $charm,
+                  repo: $repo,
+                  path: $path,
+                  release: .name,
+                  branch: .branch,
+                  cycle: (.cycle | tostring),
+                  lts: (.support.lts // false)
+                }
+            ]')"
+          echo "Found $(echo "$matrix" | jq length) charm releases to scan"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  scan:
+    name: Scan ${{ matrix.charm }} (${{ matrix.release }})
+    needs: build-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo snap install just --classic
+          sudo snap install astral-uv --classic
+
+      # A plain `git clone` (rather than actions/checkout) is used here so that a
+      # missing branch's own error output can be captured into the same report the
+      # scan output goes into, instead of only being visible in this job's log.
+      - name: Clone ${{ matrix.repo }}@${{ matrix.branch }}
+        id: checkout
+        continue-on-error: true
+        env:
+          REPO: ${{ matrix.repo }}
+          BRANCH: ${{ matrix.branch }}
+        run: |
+          set -o pipefail
+          git clone --depth=1 --branch "$BRANCH" "https://github.com/${REPO}.git" charm-checkout \
+            2>&1 | tee "$RUNNER_TEMP/scan-output.log"
+
+      - name: Run security scan
+        id: scan
+        if: steps.checkout.outcome == 'success'
+        continue-on-error: true
+        working-directory: charm-checkout/${{ matrix.path }}
+        run: |
+          set -o pipefail
+          just scan 2>&1 | tee "$RUNNER_TEMP/scan-output.log"
+
+      - name: Record result
+        id: result
+        if: always()
+        env:
+          CHARM: ${{ matrix.charm }}
+          RELEASE: ${{ matrix.release }}
+          CYCLE: ${{ matrix.cycle }}
+          LTS: ${{ matrix.lts }}
+          REPO: ${{ matrix.repo }}
+          BRANCH: ${{ matrix.branch }}
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
+          SCAN_OUTCOME: ${{ steps.scan.outcome }}
+        run: |
+          set -euo pipefail
+          if [[ "$CHECKOUT_OUTCOME" != "success" ]]; then
+            status="checkout-failed"
+          elif [[ "$SCAN_OUTCOME" == "failure" ]]; then
+            status="vulnerabilities-found"
+          else
+            status="pass"
+          fi
+
+          log_file="$RUNNER_TEMP/scan-output.log"
+          [[ -f "$log_file" ]] || echo "(no output captured)" > "$log_file"
+
+          mkdir -p "$RUNNER_TEMP/result"
+          jq -n \
+            --arg charm "$CHARM" \
+            --arg release "$RELEASE" \
+            --arg cycle "$CYCLE" \
+            --argjson lts "$LTS" \
+            --arg repo "$REPO" \
+            --arg branch "$BRANCH" \
+            --arg status "$status" \
+            --rawfile log "$log_file" \
+            '{charm:$charm, release:$release, cycle:$cycle, lts:$lts, repo:$repo, branch:$branch, status:$status, log:$log}' \
+            > "$RUNNER_TEMP/result/result.json"
+
+      - name: Upload scan result
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: scan-result-${{ matrix.charm }}-${{ matrix.release }}
+          path: ${{ runner.temp }}/result/result.json
+          if-no-files-found: error
+
+      # Runs last so the result is always recorded and uploaded first: a missing
+      # branch (or any other clone problem) should fail this job and the overall
+      # run, but vulnerabilities found by `just scan` should not.
+      - name: Fail on checkout error
+        if: steps.checkout.outcome == 'failure'
+        run: |
+          echo "::error::Failed to clone ${{ matrix.repo }}@${{ matrix.branch }} - see the 'Clone' step above for details."
+          exit 1
+
+  report:
+    name: Publish report
+    needs: scan
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download scan results
+        uses: actions/download-artifact@v7
+        with:
+          pattern: scan-result-*
+          path: results
+
+      - name: Build report
+        run: |
+          python3 - <<'EOF'
+          import glob
+          import html
+          import json
+          import os
+
+          results = []
+          for path in glob.glob("results/*/result.json"):
+              with open(path) as f:
+                  results.append(json.load(f))
+
+          summary_path = os.environ["GITHUB_STEP_SUMMARY"]
+
+          if not results:
+              with open(summary_path, "a") as f:
+                  f.write("# :mag: Charm Security Scan Report\n\n")
+                  f.write("No charm releases found in `manifest.yaml`.\n")
+              raise SystemExit(0)
+
+          results.sort(key=lambda r: (r["cycle"], r["charm"], r["release"]))
+
+          badges = {
+              "pass": "✅",
+              "vulnerabilities-found": "⚠️",
+              "checkout-failed": "❌",
+          }
+          status_text = {
+              "pass": "pass",
+              "vulnerabilities-found": "vulnerabilities found",
+              "checkout-failed": "checkout failed",
+          }
+
+          counts = {"pass": 0, "vulnerabilities-found": 0, "checkout-failed": 0}
+          for r in results:
+              counts[r["status"]] += 1
+
+          lines = []
+          lines.append("# :mag: Charm Security Scan Report")
+          lines.append("")
+          lines.append(
+              f"**{len(results)} releases scanned** · "
+              f"{badges['pass']} {counts['pass']} pass · "
+              f"{badges['vulnerabilities-found']} {counts['vulnerabilities-found']} flagged · "
+              f"{badges['checkout-failed']} {counts['checkout-failed']} checkout failed"
+          )
+          lines.append("")
+
+          current_cycle = None
+          for r in results:
+              if r["cycle"] != current_cycle:
+                  current_cycle = r["cycle"]
+                  lines.append(f"## Cycle `{current_cycle}`")
+                  lines.append("")
+
+              badge = badges[r["status"]]
+              lts_label = "LTS" if r["lts"] else "non-LTS"
+              summary = (
+                  f"{badge} <b>{r['charm']}</b> {r['release']} ({lts_label}) "
+                  f"— {status_text[r['status']]}"
+              )
+              lines.append("<details>")
+              lines.append(f"<summary>{summary}</summary>")
+              lines.append("")
+              lines.append(f"`{r['repo']}@{r['branch']}`")
+              lines.append("")
+              lines.append(f"<pre>{html.escape(r['log'])}</pre>")
+              lines.append("</details>")
+              lines.append("")
+
+          with open(summary_path, "a") as f:
+              f.write("\n".join(lines) + "\n")
+
+          if counts["checkout-failed"] > 0:
+              print(f"::error::{counts['checkout-failed']} charm(s) failed to check out; see the report above.")
+              raise SystemExit(1)
+          EOF

--- a/.github/workflows/_local-charm-scan.yaml
+++ b/.github/workflows/_local-charm-scan.yaml
@@ -22,7 +22,7 @@ jobs:
         id: matrix
         run: |
           set -euo pipefail
-          matrix="$(just list-scan-matrix)"
+          matrix="$(just security::scan-matrix)"
           releases="$(echo "$matrix" | jq '[.[].charms[]] | length')"
           repos="$(echo "$matrix" | jq length)"
           echo "Found $releases charm releases across $repos repo clones"
@@ -46,11 +46,11 @@ jobs:
           sudo snap install yq
           sudo snap install astral-uv --classic
 
-      # All the cloning/checkout/scanning logic lives in `just scan-repo` (see
-      # justfile) so it can be run and debugged locally the same way CI runs it,
-      # e.g.: just scan-repo canonical/litmus-operators
+      # All the cloning/checkout/scanning logic lives in `security.just` so it
+      # can be run and debugged locally the same way CI runs it, e.g.:
+      # just security::scan-repo canonical/litmus-operators
       - name: Scan ${{ matrix.repo }}
-        run: just scan-repo "${{ matrix.repo }}"
+        run: just security::scan-repo "${{ matrix.repo }}"
 
       - name: Compute artifact name
         if: always()
@@ -74,6 +74,12 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: sudo snap install just --classic
+
       - name: Download scan results
         uses: actions/download-artifact@v7
         with:
@@ -81,80 +87,4 @@ jobs:
           path: results
 
       - name: Build report
-        run: |
-          python3 - <<'EOF'
-          import glob
-          import html
-          import json
-          import os
-
-          results = []
-          for path in glob.glob("results/*/*.json"):
-              with open(path) as f:
-                  results.append(json.load(f))
-
-          summary_path = os.environ["GITHUB_STEP_SUMMARY"]
-
-          if not results:
-              with open(summary_path, "a") as f:
-                  f.write("# :mag: Charm Security Scan Report\n\n")
-                  f.write("No charm releases found in `manifest.yaml`.\n")
-              raise SystemExit(0)
-
-          results.sort(key=lambda r: (r["cycle"], r["charm"], r["release"]))
-
-          badges = {
-              "pass": "✅",
-              "vulnerabilities-found": "⚠️",
-              "checkout-failed": "❌",
-          }
-          status_text = {
-              "pass": "pass",
-              "vulnerabilities-found": "vulnerabilities found",
-              "checkout-failed": "checkout failed",
-          }
-
-          counts = {"pass": 0, "vulnerabilities-found": 0, "checkout-failed": 0}
-          for r in results:
-              counts[r["status"]] += 1
-
-          lines = []
-          lines.append("# :mag: Charm Security Scan Report")
-          lines.append("")
-          lines.append(
-              f"**{len(results)} releases scanned** · "
-              f"{badges['pass']} {counts['pass']} pass · "
-              f"{badges['vulnerabilities-found']} {counts['vulnerabilities-found']} flagged · "
-              f"{badges['checkout-failed']} {counts['checkout-failed']} checkout failed"
-          )
-          lines.append("")
-
-          current_cycle = None
-          for r in results:
-              if r["cycle"] != current_cycle:
-                  current_cycle = r["cycle"]
-                  lines.append(f"## Cycle `{current_cycle}`")
-                  lines.append("")
-
-              badge = badges[r["status"]]
-              lts_label = "LTS" if r["lts"] else "non-LTS"
-              summary = (
-                  f"{badge} <b>{r['charm']}</b> {r['release']} ({lts_label}) "
-                  f"— {status_text[r['status']]}"
-              )
-              lines.append("<details>")
-              lines.append(f"<summary>{summary}</summary>")
-              lines.append("")
-              lines.append(f"`{r['repo']}@{r['branch']}`")
-              lines.append("")
-              lines.append(f"<pre>{html.escape(r['log'])}</pre>")
-              lines.append("</details>")
-              lines.append("")
-
-          with open(summary_path, "a") as f:
-              f.write("\n".join(lines) + "\n")
-
-          if counts["checkout-failed"] > 0:
-              print(f"::error::{counts['checkout-failed']} charm(s) failed to check out; see the report above.")
-              raise SystemExit(1)
-          EOF
+        run: just security::build-report results >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/_local-charm-scan.yaml
+++ b/.github/workflows/_local-charm-scan.yaml
@@ -1,4 +1,4 @@
-name: Charm Security Scan (fleet-wide)
+name: Charm Security Scan
 
 on:
   workflow_dispatch:
@@ -17,9 +17,6 @@ jobs:
           sudo snap install yq
           sudo snap install astral-uv --classic
 
-      # All the cloning/checkout/scanning logic lives in `security.just` so it
-      # can be run and debugged locally the same way CI runs it, e.g.:
-      # just security::scan-charms
       - name: Scan every charm in manifest.yaml
         run: just security::scan-charms
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 **/dist/**
 venv
 .idea/
+
+# Scratch dirs left behind by `just security::scan-repo` / `build-report`
+# when run locally outside CI (where $RUNNER_TEMP isn't set).
+/charm-checkout/
+/results/

--- a/justfile
+++ b/justfile
@@ -65,6 +65,34 @@ list-expired:
     | [$type, $artifact, .name, .support.end_of_life] | @tsv
   ' | column -t -s $'\t'
 
+# List the charm-scan matrix as JSON, one entry per unique repo
+[group("manifest")]
+list-scan-matrix:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  # One entry per repo, with the charms/paths/branches it hosts - used as the
+  # matrix for the _local-charm-scan.yaml workflow (see also: `just scan-repo`).
+  yq -o=json manifest.yaml | jq -c '
+    [.artifacts.charms[]
+      | .name as $charm | .repo as $repo | .path as $path
+      | .releases[]?
+      | {
+          repo: $repo,
+          branch: .branch,
+          charm: $charm,
+          path: $path,
+          release: .name,
+          cycle: (.cycle | tostring),
+          lts: (.support.lts // false)
+        }
+    ]
+    | group_by(.repo)
+    | map({
+        repo: .[0].repo,
+        charms: map({charm, path, release, branch, cycle, lts})
+      })
+  '
+
 # Remove releases from the manifest that are past their end of life
 [group("manifest")]
 remove-expired:
@@ -111,3 +139,75 @@ promote-train charm:
     charmcraft promote --yes --name "{{charm}}" --from-channel="${track}/edge" --to-channel="${track}/beta"
     charmcraft promote --yes --name "{{charm}}" --from-channel="${track}/edge" --to-channel="${track}/candidate"
   done
+
+# Scan every charm hosted in one repo for security vulnerabilities
+[group("scan")]
+[arg("repo", help="Repository in 'org/repo' form, as it appears in manifest.yaml")]
+scan-repo repo:
+  #!/usr/bin/env python3
+  # Clones `repo` once and checks out each branch it hosts charms on in turn,
+  # running `just scan` per charm and writing one result JSON per charm under
+  # $RUNNER_TEMP/results (or ./results outside CI). Exits non-zero if any branch
+  # failed to check out; vulnerabilities found by `just scan` are recorded but
+  # don't fail the recipe. Used by the _local-charm-scan.yaml workflow, but also
+  # runs standalone, e.g.: just scan-repo canonical/litmus-operators
+  import json
+  import os
+  import subprocess
+  import sys
+  from pathlib import Path
+
+  repo = "{{ repo }}"
+  results_dir = Path(os.environ.get("RUNNER_TEMP", ".")) / "results"
+  results_dir.mkdir(parents=True, exist_ok=True)
+
+  def run(*args, cwd=None):
+      # Merge stdout/stderr (like a shell's `2>&1`) so captured logs read in order.
+      return subprocess.run(args, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+  def record(charm, release, cycle, lts, branch, status, log):
+      result = {
+          "charm": charm, "release": release, "cycle": cycle, "lts": lts,
+          "repo": repo, "branch": branch, "status": status,
+          "log": log or "(no output captured)",
+      }
+      (results_dir / f"{charm}-{release}.json").write_text(json.dumps(result))
+
+  matrix = json.loads(subprocess.run(
+      ["just", "list-scan-matrix"], capture_output=True, text=True, check=True
+  ).stdout)
+  entry = next((e for e in matrix if e["repo"] == repo), None)
+  charms = entry["charms"] if entry else []
+  if not charms:
+      print(f"No charms found for repo '{repo}' in manifest.yaml", file=sys.stderr)
+      sys.exit(1)
+
+  checkout_dir = Path("charm-checkout")
+  clone = run(
+      "git", "clone", "--quiet", "--no-checkout", "--depth=1", "--no-single-branch",
+      f"https://github.com/{repo}.git", str(checkout_dir),
+  )
+
+  any_failed = False
+  if clone.returncode != 0:
+      any_failed = True
+      for c in charms:
+          record(c["charm"], c["release"], c["cycle"], c["lts"], c["branch"], "checkout-failed", clone.stdout)
+  else:
+      for branch in sorted({c["branch"] for c in charms}):
+          checkout = run("git", "checkout", "--quiet", "-B", branch, f"origin/{branch}", cwd=checkout_dir)
+          branch_ok = checkout.returncode == 0
+          any_failed = any_failed or not branch_ok
+
+          for c in (c for c in charms if c["branch"] == branch):
+              if not branch_ok:
+                  status, log = "checkout-failed", checkout.stdout
+              else:
+                  scan = run("just", "scan", cwd=checkout_dir / c["path"])
+                  status = "pass" if scan.returncode == 0 else "vulnerabilities-found"
+                  log = scan.stdout
+              record(c["charm"], c["release"], c["cycle"], c["lts"], branch, status, log)
+
+  if any_failed:
+      print(f"::error::One or more branches of {repo} failed to check out", file=sys.stderr)
+      sys.exit(1)

--- a/justfile
+++ b/justfile
@@ -1,6 +1,8 @@
 set quiet  # Recipes are silent by default
 set export  # Just variables are exported to the environment
 
+mod security
+
 [private]
 default:
   just --list
@@ -28,21 +30,21 @@ list-repos:
   } | { grep -vxF -f <(printf '%s\n' "${ignore[@]}") || true; } | sort -u
 
 # List all charms from the manifest
-[group("manifest")]
+[group("info")]
 list-charms:
   #!/usr/bin/env bash
   set -euo pipefail
   yq -r '.artifacts.charms[].name' manifest.yaml | sort -u
 
 # List all rocks from the manifest
-[group("manifest")]
+[group("info")]
 list-rocks:
   #!/usr/bin/env bash
   set -euo pipefail
   yq -r '.artifacts.rocks[].name' manifest.yaml | sort -u
 
 # List all snaps from the manifest
-[group("manifest")]
+[group("info")]
 list-snaps:
   #!/usr/bin/env bash
   set -euo pipefail
@@ -64,34 +66,6 @@ list-expired:
     | select(.support.end_of_life != null and .support.end_of_life < $today)
     | [$type, $artifact, .name, .support.end_of_life] | @tsv
   ' | column -t -s $'\t'
-
-# List the charm-scan matrix as JSON, one entry per unique repo
-[group("manifest")]
-list-scan-matrix:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  # One entry per repo, with the charms/paths/branches it hosts - used as the
-  # matrix for the _local-charm-scan.yaml workflow (see also: `just scan-repo`).
-  yq -o=json manifest.yaml | jq -c '
-    [.artifacts.charms[]
-      | .name as $charm | .repo as $repo | .path as $path
-      | .releases[]?
-      | {
-          repo: $repo,
-          branch: .branch,
-          charm: $charm,
-          path: $path,
-          release: .name,
-          cycle: (.cycle | tostring),
-          lts: (.support.lts // false)
-        }
-    ]
-    | group_by(.repo)
-    | map({
-        repo: .[0].repo,
-        charms: map({charm, path, release, branch, cycle, lts})
-      })
-  '
 
 # Remove releases from the manifest that are past their end of life
 [group("manifest")]
@@ -139,75 +113,3 @@ promote-train charm:
     charmcraft promote --yes --name "{{charm}}" --from-channel="${track}/edge" --to-channel="${track}/beta"
     charmcraft promote --yes --name "{{charm}}" --from-channel="${track}/edge" --to-channel="${track}/candidate"
   done
-
-# Scan every charm hosted in one repo for security vulnerabilities
-[group("scan")]
-[arg("repo", help="Repository in 'org/repo' form, as it appears in manifest.yaml")]
-scan-repo repo:
-  #!/usr/bin/env python3
-  # Clones `repo` once and checks out each branch it hosts charms on in turn,
-  # running `just scan` per charm and writing one result JSON per charm under
-  # $RUNNER_TEMP/results (or ./results outside CI). Exits non-zero if any branch
-  # failed to check out; vulnerabilities found by `just scan` are recorded but
-  # don't fail the recipe. Used by the _local-charm-scan.yaml workflow, but also
-  # runs standalone, e.g.: just scan-repo canonical/litmus-operators
-  import json
-  import os
-  import subprocess
-  import sys
-  from pathlib import Path
-
-  repo = "{{ repo }}"
-  results_dir = Path(os.environ.get("RUNNER_TEMP", ".")) / "results"
-  results_dir.mkdir(parents=True, exist_ok=True)
-
-  def run(*args, cwd=None):
-      # Merge stdout/stderr (like a shell's `2>&1`) so captured logs read in order.
-      return subprocess.run(args, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
-
-  def record(charm, release, cycle, lts, branch, status, log):
-      result = {
-          "charm": charm, "release": release, "cycle": cycle, "lts": lts,
-          "repo": repo, "branch": branch, "status": status,
-          "log": log or "(no output captured)",
-      }
-      (results_dir / f"{charm}-{release}.json").write_text(json.dumps(result))
-
-  matrix = json.loads(subprocess.run(
-      ["just", "list-scan-matrix"], capture_output=True, text=True, check=True
-  ).stdout)
-  entry = next((e for e in matrix if e["repo"] == repo), None)
-  charms = entry["charms"] if entry else []
-  if not charms:
-      print(f"No charms found for repo '{repo}' in manifest.yaml", file=sys.stderr)
-      sys.exit(1)
-
-  checkout_dir = Path("charm-checkout")
-  clone = run(
-      "git", "clone", "--quiet", "--no-checkout", "--depth=1", "--no-single-branch",
-      f"https://github.com/{repo}.git", str(checkout_dir),
-  )
-
-  any_failed = False
-  if clone.returncode != 0:
-      any_failed = True
-      for c in charms:
-          record(c["charm"], c["release"], c["cycle"], c["lts"], c["branch"], "checkout-failed", clone.stdout)
-  else:
-      for branch in sorted({c["branch"] for c in charms}):
-          checkout = run("git", "checkout", "--quiet", "-B", branch, f"origin/{branch}", cwd=checkout_dir)
-          branch_ok = checkout.returncode == 0
-          any_failed = any_failed or not branch_ok
-
-          for c in (c for c in charms if c["branch"] == branch):
-              if not branch_ok:
-                  status, log = "checkout-failed", checkout.stdout
-              else:
-                  scan = run("just", "scan", cwd=checkout_dir / c["path"])
-                  status = "pass" if scan.returncode == 0 else "vulnerabilities-found"
-                  log = scan.stdout
-              record(c["charm"], c["release"], c["cycle"], c["lts"], branch, status, log)
-
-  if any_failed:
-      print(f"::error::One or more branches of {repo} failed to check out", file=sys.stderr)
-      sys.exit(1)

--- a/security.just
+++ b/security.just
@@ -1,0 +1,186 @@
+set quiet  # Recipes are silent by default
+set export  # Just variables are exported to the environment
+
+# List the charm-scan matrix as JSON, one entry per unique repo
+[group("security")]
+scan-matrix:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  # One entry per repo, with the charms/paths/branches it hosts - used as the
+  # matrix for the _local-charm-scan.yaml workflow (see also: `scan-repo`).
+  yq -o=json manifest.yaml | jq -c '
+    [.artifacts.charms[]
+      | .name as $charm | .repo as $repo | .path as $path
+      | .releases[]?
+      | {
+          repo: $repo,
+          branch: .branch,
+          charm: $charm,
+          path: $path,
+          release: .name,
+          cycle: (.cycle | tostring),
+          lts: (.support.lts // false)
+        }
+    ]
+    | group_by(.repo)
+    | map({
+        repo: .[0].repo,
+        charms: map({charm, path, release, branch, cycle, lts})
+      })
+  '
+
+# Scan every charm hosted in one repo for security vulnerabilities
+[group("security")]
+[arg("repo", help="Repository in 'org/repo' form, as it appears in manifest.yaml")]
+scan-repo repo:
+  #!/usr/bin/env python3
+  # Clones `repo` once and checks out each branch it hosts charms on in turn -
+  # only branches that are actually listed in manifest.yaml, nothing else -
+  # running `just scan` per charm and writing one result JSON per charm under
+  # $RUNNER_TEMP/results (or ./results outside CI). Exits non-zero if any branch
+  # failed to check out; vulnerabilities found by `just scan` are recorded but
+  # don't fail the recipe. Used by the _local-charm-scan.yaml workflow, but also
+  # runs standalone, e.g.: just security::scan-repo canonical/litmus-operators
+  import json
+  import os
+  import subprocess
+  import sys
+  from pathlib import Path
+
+  repo = "{{ repo }}"
+  results_dir = Path(os.environ.get("RUNNER_TEMP", ".")) / "results"
+  results_dir.mkdir(parents=True, exist_ok=True)
+
+  def run(*args, cwd=None):
+      # Merge stdout/stderr (like a shell's `2>&1`) so captured logs read in order.
+      return subprocess.run(args, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+  def record(charm, release, cycle, lts, branch, status, log):
+      result = {
+          "charm": charm, "release": release, "cycle": cycle, "lts": lts,
+          "repo": repo, "branch": branch, "status": status,
+          "log": log or "(no output captured)",
+      }
+      (results_dir / f"{charm}-{release}.json").write_text(json.dumps(result))
+
+  # A fresh `just` subprocess re-resolves modules from scratch, so sibling
+  # recipes in this same module still need their fully-qualified name here.
+  matrix = json.loads(subprocess.run(
+      ["just", "security::scan-matrix"], capture_output=True, text=True, check=True
+  ).stdout)
+  entry = next((e for e in matrix if e["repo"] == repo), None)
+  charms = entry["charms"] if entry else []
+  if not charms:
+      print(f"No charms found for repo '{repo}' in manifest.yaml", file=sys.stderr)
+      sys.exit(1)
+
+  checkout_dir = Path("charm-checkout")
+  clone = run(
+      "git", "clone", "--quiet", "--no-checkout", "--depth=1", "--no-single-branch",
+      f"https://github.com/{repo}.git", str(checkout_dir),
+  )
+
+  any_failed = False
+  if clone.returncode != 0:
+      any_failed = True
+      for c in charms:
+          record(c["charm"], c["release"], c["cycle"], c["lts"], c["branch"], "checkout-failed", clone.stdout)
+  else:
+      for branch in sorted({c["branch"] for c in charms}):
+          checkout = run("git", "checkout", "--quiet", "-B", branch, f"origin/{branch}", cwd=checkout_dir)
+          branch_ok = checkout.returncode == 0
+          any_failed = any_failed or not branch_ok
+
+          for c in (c for c in charms if c["branch"] == branch):
+              if not branch_ok:
+                  status, log = "checkout-failed", checkout.stdout
+              else:
+                  scan = run("just", "scan", cwd=checkout_dir / c["path"])
+                  status = "pass" if scan.returncode == 0 else "vulnerabilities-found"
+                  log = scan.stdout
+              record(c["charm"], c["release"], c["cycle"], c["lts"], branch, status, log)
+
+  if any_failed:
+      print(f"::error::One or more branches of {repo} failed to check out", file=sys.stderr)
+      sys.exit(1)
+
+# Build the charm-scan markdown report from a directory of result JSON files
+[group("security")]
+build-report results_dir="results":
+  #!/usr/bin/env python3
+  # Searches results_dir recursively, so this works with both a flat directory
+  # and the one-artifact-per-repo-subdirectory layout actions/download-artifact
+  # produces. Prints the report to stdout - redirect it into $GITHUB_STEP_SUMMARY
+  # in CI, or just read it directly when running locally, e.g.:
+  #   just security::build-report results
+  # Exits non-zero if any result was checkout-failed (does not affect stdout).
+  import glob
+  import html
+  import json
+  import sys
+
+  results = []
+  for path in glob.glob("{{ results_dir }}/**/*.json", recursive=True):
+      with open(path) as f:
+          results.append(json.load(f))
+
+  if not results:
+      print("# :mag: Charm Security Scan Report\n")
+      print("No charm releases found in `manifest.yaml`.")
+      sys.exit(0)
+
+  results.sort(key=lambda r: (r["cycle"], r["charm"], r["release"]))
+
+  badges = {
+      "pass": "✅",
+      "vulnerabilities-found": "⚠️",
+      "checkout-failed": "❌",
+  }
+  status_text = {
+      "pass": "pass",
+      "vulnerabilities-found": "vulnerabilities found",
+      "checkout-failed": "checkout failed",
+  }
+
+  counts = {"pass": 0, "vulnerabilities-found": 0, "checkout-failed": 0}
+  for r in results:
+      counts[r["status"]] += 1
+
+  lines = []
+  lines.append("# :mag: Charm Security Scan Report")
+  lines.append("")
+  lines.append(
+      f"**{len(results)} releases scanned** · "
+      f"{badges['pass']} {counts['pass']} pass · "
+      f"{badges['vulnerabilities-found']} {counts['vulnerabilities-found']} flagged · "
+      f"{badges['checkout-failed']} {counts['checkout-failed']} checkout failed"
+  )
+  lines.append("")
+
+  current_cycle = None
+  for r in results:
+      if r["cycle"] != current_cycle:
+          current_cycle = r["cycle"]
+          lines.append(f"## Cycle `{current_cycle}`")
+          lines.append("")
+
+      badge = badges[r["status"]]
+      lts_label = "LTS" if r["lts"] else "non-LTS"
+      summary = (
+          f"{badge} <b>{r['charm']}</b> {r['release']} ({lts_label}) "
+          f"— {status_text[r['status']]}"
+      )
+      lines.append("<details>")
+      lines.append(f"<summary>{summary}</summary>")
+      lines.append("")
+      lines.append(f"`{r['repo']}@{r['branch']}`")
+      lines.append("")
+      lines.append(f"<pre>{html.escape(r['log'])}</pre>")
+      lines.append("</details>")
+      lines.append("")
+
+  print("\n".join(lines))
+
+  if counts["checkout-failed"] > 0:
+      print(f"::error::{counts['checkout-failed']} charm(s) failed to check out; see the report above.", file=sys.stderr)
+      sys.exit(1)

--- a/security.just
+++ b/security.just
@@ -5,13 +5,14 @@ set export  # Just variables are exported to the environment
 default:
   just -f security.just --list
 
-# List the charm-scan matrix as JSON, one entry per unique repo
+# List every charm release as JSON, grouped by unique repo
 [group("security")]
 scan-matrix:
   #!/usr/bin/env bash
   set -euo pipefail
-  # One entry per repo, with the charms/paths/branches it hosts - used as the
-  # matrix for the _local-charm-scan.yaml workflow (see also: `scan-repo`).
+  # One entry per repo, with the charms/paths/branches it hosts - used by
+  # `scan-fleet` to enumerate repos, and by `scan-repo` to look up the charms
+  # hosted in one of them.
   yq -o=json manifest.yaml | jq -c '
     [.artifacts.charms[]
       | .name as $charm | .repo as $repo | .path as $path
@@ -107,6 +108,29 @@ scan-repo repo:
   if any_failed:
       print(f"::error::One or more branches of {repo} failed to check out", file=sys.stderr)
       sys.exit(1)
+
+# Scan every charm across every repo in manifest.yaml, one repo at a time
+[group("security")]
+scan-fleet:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  # Sequential on purpose: each `scan-repo` call is a shallow clone plus a
+  # handful of lightweight `uv audit` runs, so parallelizing this across one
+  # runner per repo bought little beyond N-times the runner/artifact overhead.
+  # Continues past a repo that fails (matching scan-repo's own per-branch
+  # tolerance) but still exits non-zero at the end if any of them did.
+  matrix="$(just security::scan-matrix)"
+  releases="$(echo "$matrix" | jq '[.[].charms[]] | length')"
+  repos="$(echo "$matrix" | jq -r '.[].repo')"
+  repo_count="$(echo "$repos" | wc -l)"
+  echo "Scanning $releases charm releases across $repo_count repos"
+
+  any_failed=0
+  while IFS= read -r repo; do
+    just security::scan-repo "$repo" || any_failed=1
+  done <<< "$repos"
+
+  exit "$any_failed"
 
 # Build the charm-scan markdown report from a directory of result JSON files
 [group("security")]

--- a/security.just
+++ b/security.just
@@ -1,6 +1,10 @@
 set quiet  # Recipes are silent by default
 set export  # Just variables are exported to the environment
 
+[private]
+default:
+  just -f security.just --list
+
 # List the charm-scan matrix as JSON, one entry per unique repo
 [group("security")]
 scan-matrix:

--- a/security.just
+++ b/security.just
@@ -35,7 +35,7 @@ scan-matrix:
       })
   '
 
-# Scan every charm hosted in one repo for security vulnerabilities
+# Run `just scan` on charms in a single repository
 [group("charms")]
 [arg("repo", help="Repository in 'org/repo' form, as it appears in manifest.yaml")]
 scan-charm-repo repo:
@@ -110,7 +110,7 @@ scan-charm-repo repo:
       print(f"::error::One or more branches of {repo} failed to check out", file=sys.stderr)
       sys.exit(1)
 
-# Run `uv audit` on every charm across every repo in manifest.yaml, one repo at a time
+# Run `just scan` on every charm in manifest.yaml, one repo at a time
 [group("charms")]
 scan-charms:
   #!/usr/bin/env bash
@@ -133,7 +133,7 @@ scan-charms:
 
   exit "$any_failed"
 
-# Build the charm-scan markdown report from a directory of result JSON files
+# Build the scan-charm markdown report from a directory of result JSON files
 [group("report")]
 build-report results_dir="results":
   #!/usr/bin/env python3

--- a/security.just
+++ b/security.just
@@ -6,13 +6,14 @@ default:
   just -f security.just --list
 
 # List every charm release as JSON, grouped by unique repo
+[private]
 [group("security")]
 scan-matrix:
   #!/usr/bin/env bash
   set -euo pipefail
   # One entry per repo, with the charms/paths/branches it hosts - used by
-  # `scan-fleet` to enumerate repos, and by `scan-repo` to look up the charms
-  # hosted in one of them.
+  # `scan-charms` to enumerate repos, and by `scan-charm-repo` to look up the
+  # charms hosted in one of them.
   yq -o=json manifest.yaml | jq -c '
     [.artifacts.charms[]
       | .name as $charm | .repo as $repo | .path as $path
@@ -35,9 +36,9 @@ scan-matrix:
   '
 
 # Scan every charm hosted in one repo for security vulnerabilities
-[group("security")]
+[group("charms")]
 [arg("repo", help="Repository in 'org/repo' form, as it appears in manifest.yaml")]
-scan-repo repo:
+scan-charm-repo repo:
   #!/usr/bin/env python3
   # Clones `repo` once and checks out each branch it hosts charms on in turn -
   # only branches that are actually listed in manifest.yaml, nothing else -
@@ -45,7 +46,7 @@ scan-repo repo:
   # $RUNNER_TEMP/results (or ./results outside CI). Exits non-zero if any branch
   # failed to check out; vulnerabilities found by `just scan` are recorded but
   # don't fail the recipe. Used by the _local-charm-scan.yaml workflow, but also
-  # runs standalone, e.g.: just security::scan-repo canonical/litmus-operators
+  # runs standalone, e.g.: just security::scan-charm-repo canonical/litmus-operators
   import json
   import os
   import subprocess
@@ -109,16 +110,16 @@ scan-repo repo:
       print(f"::error::One or more branches of {repo} failed to check out", file=sys.stderr)
       sys.exit(1)
 
-# Scan every charm across every repo in manifest.yaml, one repo at a time
-[group("security")]
-scan-fleet:
+# Run `uv audit` on every charm across every repo in manifest.yaml, one repo at a time
+[group("charms")]
+scan-charms:
   #!/usr/bin/env bash
   set -euo pipefail
-  # Sequential on purpose: each `scan-repo` call is a shallow clone plus a
-  # handful of lightweight `uv audit` runs, so parallelizing this across one
+  # Sequential on purpose: each `scan-charm-repo` call is a shallow clone plus
+  # a handful of lightweight `uv audit` runs, so parallelizing this across one
   # runner per repo bought little beyond N-times the runner/artifact overhead.
-  # Continues past a repo that fails (matching scan-repo's own per-branch
-  # tolerance) but still exits non-zero at the end if any of them did.
+  # Continues past a repo that fails (matching scan-charm-repo's own
+  # per-branch tolerance) but still exits non-zero at the end if any did.
   matrix="$(just security::scan-matrix)"
   releases="$(echo "$matrix" | jq '[.[].charms[]] | length')"
   repos="$(echo "$matrix" | jq -r '.[].repo')"
@@ -127,13 +128,13 @@ scan-fleet:
 
   any_failed=0
   while IFS= read -r repo; do
-    just security::scan-repo "$repo" || any_failed=1
+    just security::scan-charm-repo "$repo" || any_failed=1
   done <<< "$repos"
 
   exit "$any_failed"
 
 # Build the charm-scan markdown report from a directory of result JSON files
-[group("security")]
+[group("report")]
 build-report results_dir="results":
   #!/usr/bin/env python3
   # Searches results_dir recursively, so this works with both a flat directory


### PR DESCRIPTION
## Summary

Adds `_local-charm-scan.yaml`, a prototype workflow (following the repo's existing `_local-*.yaml` staging convention) that walks every charm release in `manifest.yaml`, clones it at its release branch, runs `just scan`, and publishes a single grouped report to the run's job summary.

## Changes

- `build-matrix` job flattens `manifest.yaml`'s charm releases into a matrix (charm, repo, path, branch, cycle, LTS).
- `scan` job (one leg per charm release, `fail-fast: false`) clones the charm at its release branch and runs `just scan`, capturing output for the report.
- `report` job aggregates all results into `$GITHUB_STEP_SUMMARY`, grouped by release cycle, with a collapsible details block per charm showing its LTS status and raw scan output.
- A charm's branch not existing fails that leg and the overall run; vulnerabilities found by `just scan` are reported but do not fail the run.

## Notes

Manual trigger only (`workflow_dispatch`), no schedule yet. Opened as a draft since this is a first pass at a `_local-` prototype, not yet promoted to a real workflow name.